### PR TITLE
Leave the version to the release, not to the branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,35 @@ jobs:
       - name: Analyze
         run: flutter analyze --fatal-infos
 
+  # A change to the package that nobody wrote down reaches pub.dev as an
+  # unexplained difference in behaviour, and the moment to explain it is while
+  # the reason is still in front of whoever made it. Put `## Unreleased` at the
+  # top of CHANGELOG.md and write there; the release picks the version number
+  # up later, so a pull request never has to guess one.
+  changelog:
+    name: Changelog
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          # The comparison needs both ends of the pull request, not just its tip.
+          fetch-depth: 0
+      - name: Check the change is written down
+        # Refactors, test-only work and anything else with nothing to say to a
+        # user get out of this by carrying the `skip changelog` label.
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip changelog') }}
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          changed=$(git diff --name-only "$BASE" "$HEAD")
+          if echo "$changed" | grep -q '^lib/' &&
+             ! echo "$changed" | grep -qx 'CHANGELOG.md'; then
+            echo "::error::this changes lib/ but says nothing in CHANGELOG.md; write it under '## Unreleased', or add the 'skip changelog' label if there is genuinely nothing for a user to read"
+            exit 1
+          fi
+
   test:
     name: Test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,6 +53,19 @@ jobs:
             echo "::error::CHANGELOG.md has no '## $version' section"
             exit 1
           fi
+      # A version number is spent for good the first time it is published, so
+      # the second attempt on one is always a mistake: either the bump was
+      # missed, or a branch cut before an earlier release carried its number
+      # forward. Both look entirely consistent from inside the repository —
+      # pubspec and CHANGELOG agree with each other and with the tag — and only
+      # pub.dev knows the number is gone.
+      - name: Check the version is not already published
+        run: |
+          version=$(grep '^version:' pubspec.yaml | cut -d' ' -f2)
+          if curl -sf -o /dev/null "https://pub.dev/api/packages/svg_animate/versions/$version"; then
+            echo "::error::$version is already on pub.dev; raise the version in pubspec.yaml and give it its own CHANGELOG section, leaving the published one as it stands"
+            exit 1
+          fi
 
   publish:
     name: Publish to pub.dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+name: Release
+
+# Prepares a release: works out the next version, gives the accumulated
+# `## Unreleased` notes that number, and opens a pull request carrying just
+# those two edits. Publishing still happens on the tag, so that the irreversible
+# step stays a deliberate act by a person rather than a side effect of merging.
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Which part of the version to raise (below 1.0.0 a breaking change takes `minor`)'
+        required: true
+        type: choice
+        options: [patch, minor, major]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    name: Prepare the release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: main
+
+      - name: Work out the next version
+        id: version
+        run: |
+          current=$(grep '^version:' pubspec.yaml | cut -d' ' -f2)
+          IFS=. read -r major minor patch <<< "$current"
+          case "${{ inputs.bump }}" in
+            major) major=$((major + 1)); minor=0; patch=0 ;;
+            minor) minor=$((minor + 1)); patch=0 ;;
+            patch) patch=$((patch + 1)) ;;
+          esac
+          next="$major.$minor.$patch"
+          echo "current=$current" >> "$GITHUB_OUTPUT"
+          echo "next=$next" >> "$GITHUB_OUTPUT"
+          echo "raising $current to $next" >> "$GITHUB_STEP_SUMMARY"
+
+      # Releasing nothing still spends a version number, and a release with an
+      # empty CHANGELOG section cannot be explained after the fact.
+      - name: Check there is something to release
+        run: |
+          if ! grep -q '^## Unreleased$' CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no '## Unreleased' section, so nothing has been written down to release"
+            exit 1
+          fi
+
+      - name: Check the version is free
+        run: |
+          if curl -sf -o /dev/null "https://pub.dev/api/packages/svg_animate/versions/${{ steps.version.outputs.next }}"; then
+            echo "::error::${{ steps.version.outputs.next }} is already on pub.dev, so pubspec.yaml on main is behind what has been released"
+            exit 1
+          fi
+
+      - name: Give the notes their version
+        run: |
+          next='${{ steps.version.outputs.next }}'
+          sed -i "s/^## Unreleased$/## $next/" CHANGELOG.md
+          sed -i "s/^version: .*/version: $next/" pubspec.yaml
+          git --no-pager diff
+
+      - name: Open the release pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEXT: ${{ steps.version.outputs.next }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git switch -c "release/v$NEXT"
+          git commit -am "Release $NEXT"
+          git push origin "release/v$NEXT"
+          # Written to a file rather than inlined: a here-document inside a
+          # command substitution is the one shell construction bash 3.2 cannot
+          # parse, which puts the workflow beyond checking on a Mac.
+          cat > "$RUNNER_TEMP/pr-body.md" <<BODY
+          Raises the version to \`$NEXT\` and gives the \`## Unreleased\` notes that number. No other change.
+
+          Nothing in this pull request was written by hand, so there is nothing to review but the notes themselves. Read the $NEXT section of \`CHANGELOG.md\` as someone who will only ever see this version through it. Then merge, and publish by tagging the merge commit:
+
+          \`\`\`sh
+          git switch main && git pull
+          git tag v$NEXT
+          git push origin v$NEXT
+          \`\`\`
+
+          That starts \`Publish\`, which re-runs formatting, analysis and the tests against the tagged commit, checks the tag against the pubspec, checks the CHANGELOG has this section and checks the version is still free on pub.dev, and only then publishes.
+
+          CI does not run on this pull request: a run opened with the workflow's own token cannot start another workflow. The \`Publish\` run on the tag covers the same ground against the same commit.
+          BODY
+          gh pr create \
+            --base main \
+            --head "release/v$NEXT" \
+            --title "Release $NEXT" \
+            --body-file "$RUNNER_TEMP/pr-body.md"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,12 @@ for a change that seems internal: it is the only check that exercises the
 package from the outside, as a dependency of an app, rather than from its own
 tests.
 
+A pull request that touches `lib/` also has to say so in `CHANGELOG.md`, under a
+`## Unreleased` heading at the top of the file — see [Releasing](#releasing) for
+why the heading rather than a version number. Work with nothing in it for a user
+to read, such as a refactor or a test, gets past that check with the `skip
+changelog` label.
+
 Tests live alongside what they cover. `test/animation/` holds the parsing and
 sampling, which is where most of the behaviour is and where a bug is cheapest to
 pin down; `test/animated_svg_test.dart` drives the widget.
@@ -25,40 +31,63 @@ Releases are driven by a git tag, so that whatever reaches pub.dev is a commit
 that exists in the history under a name. Nothing is published from a laptop, and
 no pub.dev credentials live in this repository.
 
+### Why a pull request never names a version
+
+Nothing outside a release touches `version:` in `pubspec.yaml`. A pull request
+writes what it did under `## Unreleased` at the top of `CHANGELOG.md`, and the
+release gives those notes their number once it knows what it is.
+
+This is not tidiness. A branch that picks its version when it opens is picking
+one it cannot know is still free when it lands: release something else from
+`main` in the meantime and the branch's number is quietly spent, while every
+check keeps passing, because the pubspec and the CHANGELOG go on agreeing with
+each other. The entry then reaches pub.dev filed under a version that does not
+contain it, and a published section cannot be edited afterwards. Leaving the
+number to the release removes the guess rather than checking it.
+
 ### Cutting a release
 
-1. Decide the version. The package follows [semantic
-   versioning](https://dart.dev/tools/pub/versioning): a breaking change to
-   anything exported from `lib/svg_animate.dart` needs a major bump, or a minor
-   one while the package is below `1.0.0`.
+1. Run the **Release** workflow from the Actions tab, choosing `patch`, `minor`
+   or `major`. The package follows [semantic
+   versioning](https://dart.dev/tools/pub/versioning), under which a breaking
+   change to anything exported from `lib/svg_animate.dart` takes `major` — or
+   `minor` while the package is below `1.0.0`, where that is what a breaking
+   change is spelled.
 
-2. Bump `version:` in `pubspec.yaml` and add the matching section to
-   `CHANGELOG.md`. The heading has to read exactly `## 0.3.1` — the release
-   refuses to run otherwise, because a version that reaches pub.dev with nothing
-   written about it cannot be fixed afterwards.
+   It works out the next version, renames `## Unreleased` to it, bumps the
+   pubspec and opens a pull request with those two edits and nothing else. It
+   refuses to run if there is no `## Unreleased` section, or if the version it
+   arrived at is somehow already on pub.dev.
 
-3. Commit and push to `main`, and let CI go green.
+2. Read the new section as someone who will only ever see this version through
+   it, then merge. There is nothing else in the pull request to review, and no
+   CI on it: a run opened with the workflow's own token cannot start another
+   workflow, and the `Publish` run below covers the same ground against the same
+   commit.
 
-4. Tag that commit and push the tag:
+3. Tag the merge commit and push the tag:
 
    ```sh
-   git tag v0.3.1
-   git push origin v0.3.1
+   git switch main && git pull
+   git tag v0.3.3
+   git push origin v0.3.3
    ```
 
    The tag must be `v` followed by the version, which is the pattern pub.dev is
-   configured to trust.
+   configured to trust. This step is deliberately left to a person: it is the
+   one action in the process that cannot be taken back.
 
 Pushing the tag starts the `Publish` workflow. It re-runs formatting, analysis
 and the tests against the tagged commit, checks that the tag agrees with the
-pubspec and that the CHANGELOG has a section for the version, and only then
-publishes.
+pubspec, that the CHANGELOG has a section for the version, and that the version
+is still free on pub.dev, and only then publishes.
 
 ### When a release fails
 
 | what happened | what to do |
 |---|---|
-| `verify` failed | Nothing was published. Fix it on `main`, then `git tag -d v0.3.1 && git push origin :v0.3.1` and tag again. |
+| `Release` said there was nothing to release | No pull request since the last release wrote under `## Unreleased`. If something should have, add the section and say what changed. |
+| `verify` failed | Nothing was published. Fix it on `main`, then `git tag -d v0.3.3 && git push origin :v0.3.3` and tag again. |
 | Publishing failed after `verify` passed | Run the `Publish` workflow again from the Actions tab, picking the tag in the ref dropdown. The tag does not need to be moved or reissued. |
 | The version is on pub.dev and is wrong | It cannot be removed. It can be **retracted** within seven days, from **Admin → Retract package version** on the package page, which stops new dependants resolving to it without breaking those that already did. Then release a fixed version. |
 


### PR DESCRIPTION
Takes the version number out of the hands of the branch that changes the code, and gives it to the release.

## what went wrong, so the fix is aimed at it

`0.3.2` was released from `main` while `progressive-loading` was in review. That branch had named itself `0.3.2` when it opened, and it went on carrying that number with every check green, because the two things CI compares — the pubspec and the CHANGELOG — never stopped agreeing with each other. Nothing inside the repository could tell the number had been spent. Had it merged and tagged, a changelog entry would have landed under a version that does not contain it, and a published section cannot be edited afterwards. The same thing had already happened once with `0.3.1`.

Automating the bump would not have caught this. The bump was never the hard part — knowing whether the number is still free is.

## so a pull request no longer names a version

`## Unreleased` goes at the top of `CHANGELOG.md` and pull requests write there. `version:` in the pubspec is touched only by a release. There is no guess left to go stale.

## the Release workflow

Run from the Actions tab with `patch`, `minor` or `major`. It works out the next version, renames `## Unreleased` to it, bumps the pubspec, and opens a pull request with those two edits and nothing else. It refuses to run when there is no `## Unreleased` section — releasing nothing still spends a number — or when the version it arrived at is somehow already published.

Tagging stays manual, on purpose. Publishing is the one step that cannot be taken back, and it should read as somebody deciding to release rather than as a consequence of merging. The release pull request carries the exact commands.

## two checks for the two ways this failed

**CI — a change to `lib/` has to be written down.** Escapable with a `skip changelog` label, for refactors and tests with nothing to say to a user.

**Publish — the version is still free on pub.dev.** One `curl`. It is the only question that could not be answered from inside the repository, which is exactly why it was the one nobody asked.

## what I verified

Both guards, against the live API: `0.3.2` and `0.3.3` read as taken, `0.9.9` as free.

The release logic, run against a copy of the real files: `0.3.3` → `0.3.4` on patch, `0.4.0` on minor, `1.0.0` on major; `## Unreleased` correctly renamed and consumed, so a second run finds nothing to release and stops.

Every `run:` block parsed with `bash -n`. That caught a genuine defect: the pull request body was built with a here-document inside a command substitution, which bash 3.2 — the bash on macOS — cannot parse at all. It would have worked on the runner and been unverifiable on a laptop. The body is written to a file now.

## what is not covered

The `Release` workflow itself has never run. Its shape is checked, its logic is checked against real data, but the first real run is the first end-to-end run. The failure modes it has left are permissions and the `gh pr create` call, both of which fail loudly and before anything is published.

## no behaviour change

Workflows and `CONTRIBUTING.md` only. Nothing under `lib/`.
