### PR TITLE
Bound the animation cache by bytes, not only by entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## Unreleased
+
+* Bounds the animation cache by how much it is holding and not only by how many
+  animations it holds, through `AnimationCache.maximumSizeBytes`, which defaults
+  to 20 MiB. The count was the only limit, and how much an animation costs to
+  hold has very little to do with how many there are: a spinner compiles to a
+  few kilobytes and a banner carrying embedded bitmaps to several megabytes, so
+  the default of ten entries was somewhere between 50 KB and 50 MB depending
+  entirely on what an app happened to show. An animation larger than the whole
+  budget is still kept, alone, rather than refused — refusing it would disable
+  the cache for exactly the files whose recompilation is measured in seconds.
+  `AnimationCache.currentSizeBytes` reports what is held.
+
 ## 0.3.3
 
 * Shows the first frame while the rest are still being compiled, instead of a

--- a/lib/src/animation/cache.dart
+++ b/lib/src/animation/cache.dart
@@ -7,9 +7,22 @@ import 'frames.dart';
 /// Compiling an animation produces one encoded vector graphic per frame, which
 /// is far more expensive to build and to hold than a single static picture, so
 /// this cache holds fewer entries by default than the cache for static SVGs.
+///
+/// Entries are bounded by [maximumSizeBytes] as well as by [maximumSize],
+/// because how much an animation costs to hold and how many animations there
+/// are turn out to have very little to do with each other: a spinner compiles
+/// to a few kilobytes and a promotional banner carrying embedded bitmaps to
+/// several megabytes, so a count that is generous for one is ruinous for the
+/// other.
 class AnimationCache {
   final Map<Object, Future<AnimatedSvgFrames>> _pending = <Object, Future<AnimatedSvgFrames>>{};
   final Map<Object, AnimatedSvgFrames> _cache = <Object, AnimatedSvgFrames>{};
+
+  // Recorded when the entry goes in rather than asked of the entry when it
+  // comes out, so that what is subtracted is always exactly what was added, and
+  // so that measuring an animation stays proportional to its frame count
+  // instead of happening on every eviction.
+  final Map<Object, int> _sizes = <Object, int>{};
 
   /// Maximum number of animations to store in the cache.
   ///
@@ -33,15 +46,55 @@ class AnimationCache {
     if (_maximumSize == 0) {
       clear();
     } else {
-      while (_cache.length > _maximumSize) {
-        _cache.remove(_cache.keys.first);
-      }
+      _evictToBudget();
     }
   }
+
+  /// Maximum number of bytes of compiled animation to hold.
+  ///
+  /// Defaults to 20 MiB, which is room for a handful of the heaviest sort of
+  /// animation — a large SVG with bitmaps embedded in it — and for as many
+  /// ordinary ones as [maximumSize] allows. It sits well below the 100 MiB that
+  /// Flutter's own `ImageCache` takes by default.
+  ///
+  /// The one thing this does not do is refuse an animation bigger than the
+  /// whole budget. Refusing it would quietly disable the cache for exactly the
+  /// files that most need one, turning every rebuild back into a recompile
+  /// measured in seconds, so such an animation is kept — alone, with everything
+  /// else evicted to make room for it.
+  ///
+  /// Setting this to zero disables caching, as setting [maximumSize] to zero
+  /// does.
+  int get maximumSizeBytes => _maximumSizeBytes;
+  int _maximumSizeBytes = _defaultMaximumSizeBytes;
+  static const int _defaultMaximumSizeBytes = 20 << 20;
+
+  /// Changes the maximum number of bytes to hold.
+  ///
+  /// Anything held over the new budget is evicted immediately, least recently
+  /// used first.
+  set maximumSizeBytes(int value) {
+    assert(value >= 0);
+    if (value == _maximumSizeBytes) {
+      return;
+    }
+    _maximumSizeBytes = value;
+    if (_maximumSizeBytes == 0) {
+      clear();
+    } else {
+      _evictToBudget();
+    }
+  }
+
+  /// How many bytes of compiled animation are currently held.
+  int get currentSizeBytes => _currentSizeBytes;
+  int _currentSizeBytes = 0;
 
   /// Evicts all entries from the cache.
   void clear() {
     _cache.clear();
+    _sizes.clear();
+    _currentSizeBytes = 0;
   }
 
   /// The animation cached under [key], if it is there.
@@ -50,16 +103,16 @@ class AnimationCache {
   /// the expensive work has already been done before deciding to do anything
   /// about the wait.
   AnimatedSvgFrames? operator [](Object key) {
-    final AnimatedSvgFrames? cached = _cache.remove(key);
+    final AnimatedSvgFrames? cached = _cache[key];
     if (cached != null) {
-      _add(key, cached); // Reading counts as use.
+      _touch(key); // Reading counts as use.
     }
     return cached;
   }
 
   /// Evicts a single entry from the cache, returning true if successful.
   bool evict(Object key) {
-    return _cache.remove(key) != null;
+    return _remove(key);
   }
 
   /// The number of entries in the cache.
@@ -75,9 +128,9 @@ class AnimationCache {
       return pendingResult;
     }
 
-    final AnimatedSvgFrames? cached = _cache.remove(key);
+    final AnimatedSvgFrames? cached = _cache[key];
     if (cached != null) {
-      _add(key, cached);
+      _touch(key);
       return SynchronousFuture<AnimatedSvgFrames>(cached);
     }
 
@@ -101,15 +154,42 @@ class AnimationCache {
   }
 
   void _add(Object key, AnimatedSvgFrames frames) {
-    if (_maximumSize <= 0) {
+    if (_maximumSize <= 0 || _maximumSizeBytes <= 0) {
       return;
     }
-    if (_cache.containsKey(key)) {
-      _cache.remove(key); // Update the LRU position.
-    } else if (_cache.length >= _maximumSize) {
-      _cache.remove(_cache.keys.first);
-    }
+    _remove(key);
     _cache[key] = frames;
+    final int size = frames.compiledByteSize;
+    _sizes[key] = size;
+    _currentSizeBytes += size;
+    _evictToBudget();
+  }
+
+  bool _remove(Object key) {
+    if (_cache.remove(key) == null) {
+      return false;
+    }
+    _currentSizeBytes -= _sizes.remove(key)!;
+    return true;
+  }
+
+  /// Moves [key] to the "most recently used" position without disturbing the
+  /// accounting, which cannot have changed: an [AnimatedSvgFrames] never does.
+  void _touch(Object key) {
+    final AnimatedSvgFrames? frames = _cache.remove(key);
+    if (frames != null) {
+      _cache[key] = frames;
+    }
+  }
+
+  void _evictToBudget() {
+    // Dart maps iterate in insertion order, so the first key is the one used
+    // longest ago. The length check is what keeps a single over-budget
+    // animation from evicting itself the instant it is added.
+    while (_cache.length > _maximumSize ||
+        (_currentSizeBytes > _maximumSizeBytes && _cache.length > 1)) {
+      _remove(_cache.keys.first);
+    }
   }
 }
 
@@ -117,6 +197,6 @@ class AnimationCache {
 ///
 /// Entries are large, because an animation holds one compiled vector graphic
 /// per frame, so this holds far fewer of them than the picture caches in
-/// `package:flutter_svg` do. Lower [AnimationCache.maximumSize] to trade
+/// `package:flutter_svg` do. Lower [AnimationCache.maximumSizeBytes] to trade
 /// recompilation for memory, or set it to zero to disable caching entirely.
 final AnimationCache svgAnimateCache = AnimationCache();

--- a/test/animation/cache_test.dart
+++ b/test/animation/cache_test.dart
@@ -1,0 +1,132 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:svg_animate/src/animation/cache.dart';
+import 'package:svg_animate/src/animation/frames.dart';
+
+/// An animation of one frame occupying [bytes] bytes.
+AnimatedSvgFrames sized(int bytes) => AnimatedSvgFrames.fromEncodedFrames(
+  <Uint8List>[Uint8List(bytes)],
+  duration: const Duration(seconds: 1),
+  loops: true,
+);
+
+Future<AnimatedSvgFrames> put(AnimationCache cache, Object key, int bytes) {
+  final AnimatedSvgFrames frames = sized(bytes);
+  return cache.putIfAbsent(key, () async => frames);
+}
+
+void main() {
+  group('AnimationCache byte budget', () {
+    test('reports what it is holding', () async {
+      final AnimationCache cache = AnimationCache();
+      await put(cache, 'a', 100);
+      await put(cache, 'b', 250);
+
+      expect(cache.count, 2);
+      expect(cache.currentSizeBytes, 350);
+    });
+
+    test('evicts the least recently used until it is within budget', () async {
+      final AnimationCache cache = AnimationCache()..maximumSizeBytes = 1000;
+      await put(cache, 'a', 400);
+      await put(cache, 'b', 400);
+      await put(cache, 'c', 400);
+
+      // 'a' is the one nothing has touched since it went in.
+      expect(cache['a'], isNull);
+      expect(cache['b'], isNotNull);
+      expect(cache['c'], isNotNull);
+      expect(cache.currentSizeBytes, 800);
+    });
+
+    test('counts reading as use, so a read entry outlives an unread one', () async {
+      final AnimationCache cache = AnimationCache()..maximumSizeBytes = 1000;
+      await put(cache, 'a', 400);
+      await put(cache, 'b', 400);
+      cache['a'];
+      await put(cache, 'c', 400);
+
+      expect(cache['a'], isNotNull, reason: 'read after being added, so used more recently');
+      expect(cache['b'], isNull);
+    });
+
+    test('keeps an animation larger than the whole budget, alone', () async {
+      final AnimationCache cache = AnimationCache()..maximumSizeBytes = 1000;
+      await put(cache, 'small', 100);
+      await put(cache, 'huge', 5000);
+
+      // Refusing it would turn every rebuild of the heaviest sort of file back
+      // into a recompile, which is the one thing the cache exists to prevent.
+      expect(cache['huge'], isNotNull);
+      expect(cache['small'], isNull);
+      expect(cache.currentSizeBytes, 5000);
+
+      // And it does not wedge the cache: the next animation displaces it.
+      await put(cache, 'next', 100);
+      expect(cache['huge'], isNull);
+      expect(cache.currentSizeBytes, 100);
+    });
+
+    test('still honours the entry count', () async {
+      final AnimationCache cache = AnimationCache()
+        ..maximumSizeBytes = 1 << 30
+        ..maximumSize = 2;
+      await put(cache, 'a', 1);
+      await put(cache, 'b', 1);
+      await put(cache, 'c', 1);
+
+      expect(cache.count, 2);
+      expect(cache['a'], isNull);
+      expect(cache.currentSizeBytes, 2);
+    });
+
+    test('evicts down to a lowered budget immediately', () async {
+      final AnimationCache cache = AnimationCache();
+      await put(cache, 'a', 400);
+      await put(cache, 'b', 400);
+
+      cache.maximumSizeBytes = 500;
+
+      expect(cache.count, 1);
+      expect(cache['b'], isNotNull);
+      expect(cache.currentSizeBytes, 400);
+    });
+
+    test('a budget of zero caches nothing', () async {
+      final AnimationCache cache = AnimationCache()..maximumSizeBytes = 0;
+      await put(cache, 'a', 100);
+
+      expect(cache.count, 0);
+      expect(cache.currentSizeBytes, 0);
+    });
+
+    test('keeps the accounting straight through eviction and clearing', () async {
+      final AnimationCache cache = AnimationCache();
+      await put(cache, 'a', 100);
+      await put(cache, 'b', 200);
+
+      expect(cache.evict('a'), isTrue);
+      expect(cache.currentSizeBytes, 200);
+      expect(cache.evict('a'), isFalse, reason: 'evicting twice must not double-count');
+      expect(cache.currentSizeBytes, 200);
+
+      cache.clear();
+      expect(cache.currentSizeBytes, 0);
+
+      // Re-adding after a clear starts the count again rather than resuming it.
+      await put(cache, 'a', 100);
+      expect(cache.currentSizeBytes, 100);
+    });
+
+    test('replacing an entry does not count it twice', () async {
+      final AnimationCache cache = AnimationCache();
+      await put(cache, 'a', 100);
+      cache.evict('a');
+      await put(cache, 'a', 700);
+
+      expect(cache.count, 1);
+      expect(cache.currentSizeBytes, 700);
+    });
+  });
+}


### PR DESCRIPTION
`AnimationCache` was bounded only by entry count, at ten. An entry is anywhere between a few kilobytes and several megabytes — a spinner and the 450×450 banner with five bitmaps embedded in it differ by three orders of magnitude — so the real ceiling was somewhere between 50 KB and 50 MB depending entirely on what the app happened to show. Nothing in the API hinted at it. The number ten reads as small.

## what changed

`maximumSizeBytes`, defaulting to 20 MiB: room for a handful of the heaviest sort of animation, and well under the 100 MiB Flutter's own `ImageCache` takes. `currentSizeBytes` reports what is held. `maximumSize` keeps its meaning and still applies, so both ceilings hold at once.

`compiledByteSize` already existed, so this is bookkeeping rather than measurement. Sizes are recorded on the way in rather than asked of the entry on the way out — what gets subtracted is then exactly what was added, and measuring an animation (a fold over every frame) stays off the eviction path.

## the one judgement call

An animation larger than the entire budget is **kept, alone**, not refused.

Flutter's `ImageCache` refuses oversized entries, and copying that was tempting for the tidier invariant. But an image that misses the cache is decoded again in milliseconds, whereas one of these is recompiled in seconds — so refusing would quietly disable the cache for precisely the files that most need one, and the symptom would be a multi-second stall on rebuild with nothing anywhere saying why. It is kept with everything else evicted, and the next animation displaces it, so it cannot wedge the cache either. Both halves are tested.

## tests

Nine new ones in `test/animation/cache_test.dart`, covering eviction order, reading counting as use, the over-budget entry being kept and then displaced, the entry count still applying independently, lowering the budget evicting immediately, a zero budget caching nothing, and the accounting surviving double eviction, clearing and re-adding.

144 tests pass, analyzer clean under `--fatal-infos`.

## note

First pull request under the new release flow, so the entry goes under `## Unreleased` and the pubspec version is untouched.
