### PR TITLE
Release 0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.3.4
 
 * Bounds the animation cache by how much it is holding and not only by how many
   animations it holds, through `AnimationCache.maximumSizeBytes`, which defaults

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: svg_animate
 description: Plays SVGs that declare their own animation, in SMIL or CSS keyframes, on top of the vector_graphics renderer that flutter_svg uses.
-version: 0.3.3
+version: 0.3.4
 repository: https://github.com/Treamz/svg_animate
 issue_tracker: https://github.com/Treamz/svg_animate/issues
 


### PR DESCRIPTION
Raises the version to `0.3.4` and gives the `## Unreleased` notes that number. No other change.

Built by the `Release` workflow ([run](https://github.com/Treamz/svg_animate/actions/runs/32123035515)). The workflow produced the commit correctly and pushed the branch, then could not open this pull request itself: **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"** is off. Opened by hand instead; the contents are the workflow's, unmodified.

Then publish by tagging the merge commit:

```sh
git switch main && git pull
git tag v0.3.4
git push origin v0.3.4
```
