### PR TITLE
Stop the release workflow opening its own pull request

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,15 @@
 name: Release
 
 # Prepares a release: works out the next version, gives the accumulated
-# `## Unreleased` notes that number, and opens a pull request carrying just
-# those two edits. Publishing still happens on the tag, so that the irreversible
-# step stays a deliberate act by a person rather than a side effect of merging.
+# `## Unreleased` notes that number, and pushes a branch carrying just those two
+# edits, then links to the pull request for them.
+#
+# It stops short of opening that pull request itself, which is not a limitation
+# but the point. A pull request opened with a workflow's own token cannot start
+# another workflow, so the release commit — the one commit that reaches pub.dev
+# under a name — would be the only commit in the repository to arrive with no CI
+# on it at all. Opening it by hand is one click and buys back every check.
+# It also means this workflow needs no permission to create pull requests.
 on:
   workflow_dispatch:
     inputs:
@@ -15,7 +21,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   prepare:
@@ -39,7 +44,6 @@ jobs:
           next="$major.$minor.$patch"
           echo "current=$current" >> "$GITHUB_OUTPUT"
           echo "next=$next" >> "$GITHUB_OUTPUT"
-          echo "raising $current to $next" >> "$GITHUB_STEP_SUMMARY"
 
       # Releasing nothing still spends a version number, and a release with an
       # empty CHANGELOG section cannot be explained after the fact.
@@ -51,22 +55,25 @@ jobs:
           fi
 
       - name: Check the version is free
+        env:
+          NEXT: ${{ steps.version.outputs.next }}
         run: |
-          if curl -sf -o /dev/null "https://pub.dev/api/packages/svg_animate/versions/${{ steps.version.outputs.next }}"; then
-            echo "::error::${{ steps.version.outputs.next }} is already on pub.dev, so pubspec.yaml on main is behind what has been released"
+          if curl -sf -o /dev/null "https://pub.dev/api/packages/svg_animate/versions/$NEXT"; then
+            echo "::error::$NEXT is already on pub.dev, so pubspec.yaml on main is behind what has been released"
             exit 1
           fi
 
       - name: Give the notes their version
+        env:
+          NEXT: ${{ steps.version.outputs.next }}
         run: |
-          next='${{ steps.version.outputs.next }}'
-          sed -i "s/^## Unreleased$/## $next/" CHANGELOG.md
-          sed -i "s/^version: .*/version: $next/" pubspec.yaml
+          sed -i "s/^## Unreleased$/## $NEXT/" CHANGELOG.md
+          sed -i "s/^version: .*/version: $NEXT/" pubspec.yaml
           git --no-pager diff
 
-      - name: Open the release pull request
+      - name: Push the release branch
         env:
-          GH_TOKEN: ${{ github.token }}
+          CURRENT: ${{ steps.version.outputs.current }}
           NEXT: ${{ steps.version.outputs.next }}
         run: |
           git config user.name 'github-actions[bot]'
@@ -74,13 +81,18 @@ jobs:
           git switch -c "release/v$NEXT"
           git commit -am "Release $NEXT"
           git push origin "release/v$NEXT"
-          # Written to a file rather than inlined: a here-document inside a
-          # command substitution is the one shell construction bash 3.2 cannot
-          # parse, which puts the workflow beyond checking on a Mac.
-          cat > "$RUNNER_TEMP/pr-body.md" <<BODY
-          Raises the version to \`$NEXT\` and gives the \`## Unreleased\` notes that number. No other change.
 
-          Nothing in this pull request was written by hand, so there is nothing to review but the notes themselves. Read the $NEXT section of \`CHANGELOG.md\` as someone who will only ever see this version through it. Then merge, and publish by tagging the merge commit:
+          compare="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/compare/main...release/v$NEXT?expand=1"
+          # Written to the run summary rather than only to the log, so that the
+          # link is the first thing on the page the run finishes on.
+          cat >> "$GITHUB_STEP_SUMMARY" <<SUMMARY
+          ## Release $NEXT
+
+          Raised from \`$CURRENT\`. The branch \`release/v$NEXT\` carries the version bump and the renamed \`## Unreleased\` heading, and nothing else.
+
+          **[Open the pull request]($compare)**
+
+          Nothing on it was written by hand, so there is nothing to review but the notes themselves. Read the $NEXT section of \`CHANGELOG.md\` as someone who will only ever see this version through it. Then let CI finish, merge, and publish by tagging the merge commit:
 
           \`\`\`sh
           git switch main && git pull
@@ -89,11 +101,5 @@ jobs:
           \`\`\`
 
           That starts \`Publish\`, which re-runs formatting, analysis and the tests against the tagged commit, checks the tag against the pubspec, checks the CHANGELOG has this section and checks the version is still free on pub.dev, and only then publishes.
-
-          CI does not run on this pull request: a run opened with the workflow's own token cannot start another workflow. The \`Publish\` run on the tag covers the same ground against the same commit.
-          BODY
-          gh pr create \
-            --base main \
-            --head "release/v$NEXT" \
-            --title "Release $NEXT" \
-            --body-file "$RUNNER_TEMP/pr-body.md"
+          SUMMARY
+          echo "::notice title=Release $NEXT prepared::open the pull request at $compare"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,17 +55,23 @@ number to the release removes the guess rather than checking it.
    change is spelled.
 
    It works out the next version, renames `## Unreleased` to it, bumps the
-   pubspec and opens a pull request with those two edits and nothing else. It
+   pubspec, and pushes a branch carrying those two edits and nothing else. It
    refuses to run if there is no `## Unreleased` section, or if the version it
    arrived at is somehow already on pub.dev.
 
-2. Read the new section as someone who will only ever see this version through
-   it, then merge. There is nothing else in the pull request to review, and no
-   CI on it: a run opened with the workflow's own token cannot start another
-   workflow, and the `Publish` run below covers the same ground against the same
-   commit.
+2. Open the pull request from the link in the run summary, and let CI finish.
 
-3. Tag the merge commit and push the tag:
+   The workflow deliberately does not open it. A pull request opened with a
+   workflow's own token cannot start another workflow, so the release commit —
+   the one commit that reaches pub.dev under a name — would be the only commit
+   in the repository to arrive with nothing having checked it. One click buys
+   back every check, and the workflow needs no permission to create pull
+   requests.
+
+3. Read the new section as someone who will only ever see this version through
+   it, then merge. There is nothing else in the pull request to review.
+
+4. Tag the merge commit and push the tag:
 
    ```sh
    git switch main && git pull
@@ -87,6 +93,7 @@ is still free on pub.dev, and only then publishes.
 | what happened | what to do |
 |---|---|
 | `Release` said there was nothing to release | No pull request since the last release wrote under `## Unreleased`. If something should have, add the section and say what changed. |
+| You changed your mind before merging | Delete the `release/v0.3.3` branch. `main` still says `## Unreleased`, because the renaming only ever happened on the branch, so nothing needs undoing. |
 | `verify` failed | Nothing was published. Fix it on `main`, then `git tag -d v0.3.3 && git push origin :v0.3.3` and tag again. |
 | Publishing failed after `verify` passed | Run the `Publish` workflow again from the Actions tab, picking the tag in the ref dropdown. The tag does not need to be moved or reissued. |
 | The version is on pub.dev and is wrong | It cannot be removed. It can be **retracted** within seven days, from **Admin → Retract package version** on the package page, which stops new dependants resolving to it without breaking those that already did. Then release a fixed version. |


### PR DESCRIPTION
The first real run of `Release` ([run](https://github.com/Treamz/svg_animate/actions/runs/32123035515)) got everything right and then died on the last line: `GitHub Actions is not permitted to create or approve pull requests`. The branch and its two-line commit were already pushed and correct, so opening the pull request by hand finished the 0.3.4 release.

That detour is what makes this change, because the hand-opened pull request **got the full CI suite**, and one opened by the workflow would have got none of it — a pull request opened with a workflow's own token cannot start another workflow.

I wrote that down as a caveat when I added the workflow. I underrated it. The release commit is the one commit in the repository that reaches pub.dev under a name, and it would have been the only commit arriving with nothing having checked it. Flipping the repository setting buys one click and pays for it with every check on the commit that can least afford to lose them.

## what changed

`Release` now pushes the branch and puts a pre-filled compare link in the run summary, along with the notes to review and the tag commands. Somebody clicks once, CI runs in full, and the workflow needs no `pull-requests: write` at all — that permission is dropped.

Nothing about the version arithmetic, the `## Unreleased` requirement or the pub.dev free-version check changes.

A prepared release is also now free to abandon: delete the branch. `main` still says `## Unreleased`, because the renaming only ever happened on the branch. Written into the failure table.

## verified

Every `run:` block re-checked with `bash -n`.

The summary block executed locally with the runner's variables stubbed, and its output inspected line by line: no leading whitespace (which would have silently turned the whole thing into a code block after the YAML dedent), the compare link well-formed, `$NEXT` and `$CURRENT` substituted, the fenced block intact.

Format, analyze and 144 tests locally.

## not verified

The same gap as last time, honestly: the rewritten workflow has not run. Its logic is unchanged from the run that did work, and the step that failed is now deleted rather than replaced, so there is less to go wrong than there was — but the next release is still its first end-to-end run.

## also

`CONTRIBUTING.md` and the local skill both updated, including deleting the "no CI on it" line that is now wrong.

No change under `lib/`, so nothing for the CHANGELOG.
