### PR TITLE
Keep one copy of a frame that repeats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## Unreleased
+
+* Keeps one copy of any frame that repeats, rather than one per sampling point.
+  Frames repeat whenever the document holds still — a `<set>`, a discrete
+  `calcMode`, a CSS `steps()` timing function, a long gap between keyframes — so
+  a one-second blink compiled at the default frame rate held sixty pictures
+  where it draws two, and a `steps(4)` slide held sixty where it draws four.
+  Nothing changes for an animation whose frames all differ: the compiled size of
+  a 450x450 banner is unchanged to the byte, and the extra pass over its 300
+  frames does not measurably lengthen its 2.6 s compile.
+* Stops playing an animation that never changes what it draws. A document can
+  declare an animation the renderer cannot express — a morphing `d`, say — which
+  sampled to sixty identical pictures, reported itself as animated, and ran a
+  ticker that repainted the same picture for as long as the widget was on
+  screen. `AnimatedSvgFrames.isAnimated` now counts pictures rather than
+  sampling points, so nothing is started. `distinctFrameCount` reports how many
+  there are, next to `frameCount`, which keeps its meaning as the resolution the
+  timeline was sampled at.
+
 ## 0.3.4
 
 * Bounds the animation cache by how much it is holding and not only by how many

--- a/lib/src/animation/frames.dart
+++ b/lib/src/animation/frames.dart
@@ -33,12 +33,15 @@ class AnimatedSvgFrames {
   const AnimatedSvgFrames._({
     required Uint8List shared,
     required List<Uint8List> tails,
+    required List<int>? storage,
     required this.duration,
     required this.loops,
   }) : _shared = shared,
-       _tails = tails;
+       _tails = tails,
+       _storage = storage;
 
-  /// Splits [frames] into the part they all share and what remains of each.
+  /// Splits [frames] into the part they all share and what remains of each,
+  /// keeping only one copy of any frame that repeats.
   factory AnimatedSvgFrames.fromEncodedFrames(
     List<Uint8List> frames, {
     required Duration duration,
@@ -46,16 +49,24 @@ class AnimatedSvgFrames {
   }) {
     assert(frames.isNotEmpty);
     final int shared = _sharedPrefixLength(frames);
+    final tails = <Uint8List>[for (final Uint8List frame in frames) frame.sublist(shared)];
+    final _DistinctTails distinct = _distinctTails(tails);
     return AnimatedSvgFrames._(
       shared: frames.first.sublist(0, shared),
-      tails: <Uint8List>[for (final Uint8List frame in frames) frame.sublist(shared)],
+      tails: distinct.tails,
+      storage: distinct.storage,
       duration: duration,
       loops: loops,
     );
   }
 
   final Uint8List _shared;
+
+  /// The distinct frames, in the order they are first sampled.
   final List<Uint8List> _tails;
+
+  /// Which of [_tails] each sampled frame shows, or null when they all differ.
+  final List<int>? _storage;
 
   /// How long one pass through the frames takes.
   final Duration duration;
@@ -63,10 +74,20 @@ class AnimatedSvgFrames {
   /// Whether playback should restart after the last frame.
   final bool loops;
 
-  /// How many frames the animation was compiled into.
+  /// How many frames the animation was sampled at.
   ///
-  /// Always at least one; an SVG with no animation compiles to a single frame.
-  int get frameCount => _tails.length;
+  /// This is the resolution of the timeline rather than the number of pictures
+  /// held: frames that came out of the compiler identical are stored once, so
+  /// this can be larger than [distinctFrameCount]. Always at least one; an SVG
+  /// with no animation compiles to a single frame.
+  int get frameCount => _storage?.length ?? _tails.length;
+
+  /// How many of the sampled frames actually differ from one another.
+  ///
+  /// A document that declares an animation the renderer cannot express — a
+  /// morphing `d`, say — samples to any number of frames that are all the same
+  /// picture, and reports one here.
+  int get distinctFrameCount => _tails.length;
 
   /// How much memory the compiled frames occupy, in bytes.
   ///
@@ -75,14 +96,18 @@ class AnimatedSvgFrames {
       _shared.length + _tails.fold(0, (int total, Uint8List tail) => total + tail.length);
 
   /// Whether there is anything to play.
-  bool get isAnimated => frameCount > 1 && duration > Duration.zero;
+  ///
+  /// Counts pictures rather than sampling points, so an animation that never
+  /// changes what it draws is not played: there is nothing for a ticker to do
+  /// but repaint the same picture until the widget goes away.
+  bool get isAnimated => distinctFrameCount > 1 && duration > Duration.zero;
 
   /// The encoded vector graphic for the frame at [index].
   ///
   /// Rebuilt on each call from the shared part and the frame's own, which costs
   /// a copy of a few tens of kilobytes and saves holding every frame whole.
   ByteData frameAt(int index) {
-    final Uint8List tail = _tails[index];
+    final Uint8List tail = _tails[_storageIndexAt(index)];
     if (_shared.isEmpty) {
       return tail.buffer.asByteData(tail.offsetInBytes, tail.lengthInBytes);
     }
@@ -105,6 +130,85 @@ class AnimatedSvgFrames {
     }
     return (progress.clamp(0.0, 1.0) * (frameCount - 1)).round();
   }
+
+  /// Which stored picture the frame at [index] shows.
+  ///
+  /// Two frames that resolve to the same picture are the same picture, which is
+  /// what lets playback skip decoding one it is already showing.
+  int _storageIndexAt(int index) => _storage?[index] ?? index;
+}
+
+/// The distinct entries of a list of frame tails, and where each frame found
+/// its own.
+class _DistinctTails {
+  const _DistinctTails(this.tails, this.storage);
+
+  final List<Uint8List> tails;
+
+  /// Null when nothing repeated, so that the common case carries no table.
+  final List<int>? storage;
+}
+
+/// Keeps one copy of each distinct entry of [tails].
+///
+/// Frames repeat whenever the document holds still: a `<set>`, a discrete
+/// `calcMode`, a CSS `steps()` timing function, or simply a long gap between
+/// keyframes all sample to the same picture many times over. So does an
+/// animation of something the renderer cannot draw, which samples to nothing
+/// but copies of one frame.
+_DistinctTails _distinctTails(List<Uint8List> tails) {
+  if (tails.length == 1) {
+    return _DistinctTails(tails, null);
+  }
+  // Digests first, because comparing every frame against every distinct one it
+  // is not equal to would cost the square of the frame count in byte
+  // comparisons. A collision costs one comparison that fails; equality is never
+  // concluded from the digest alone.
+  final buckets = <int, List<int>>{};
+  final distinct = <Uint8List>[];
+  final storage = List<int>.filled(tails.length, 0);
+  for (var index = 0; index < tails.length; index += 1) {
+    final Uint8List tail = tails[index];
+    final List<int> bucket = buckets.putIfAbsent(_digest(tail), () => <int>[]);
+    var found = -1;
+    for (final int candidate in bucket) {
+      if (_sameBytes(distinct[candidate], tail)) {
+        found = candidate;
+        break;
+      }
+    }
+    if (found < 0) {
+      found = distinct.length;
+      distinct.add(tail);
+      bucket.add(found);
+    }
+    storage[index] = found;
+  }
+  if (distinct.length == tails.length) {
+    return _DistinctTails(tails, null);
+  }
+  return _DistinctTails(distinct, storage);
+}
+
+/// An FNV-1a digest of [bytes], masked to stay a small integer everywhere.
+int _digest(Uint8List bytes) {
+  var hash = 0x811c9dc5;
+  for (var i = 0; i < bytes.length; i += 1) {
+    hash = ((hash ^ bytes[i]) * 0x01000193) & 0x3fffffff;
+  }
+  return hash ^ bytes.length;
+}
+
+bool _sameBytes(Uint8List a, Uint8List b) {
+  if (a.length != b.length) {
+    return false;
+  }
+  for (var i = 0; i < a.length; i += 1) {
+    if (a[i] != b[i]) {
+      return false;
+    }
+  }
+  return true;
 }
 
 /// The length of the longest run of bytes every one of [frames] starts with.
@@ -208,14 +312,19 @@ class AnimatedSvgFrameLoader extends BytesLoader {
   Future<ByteData> loadBytes(BuildContext? context) =>
       SynchronousFuture<ByteData>(frames.frameAt(frameIndex));
 
+  // Both of these speak in stored pictures rather than in frame numbers, so
+  // that a run of frames the compiler produced identically is recognised as the
+  // one picture it is: the widget then neither reloads it nor caches it twice
+  // while the animation sits on it.
   @override
-  Object cacheKey(BuildContext? context) => _AnimatedSvgFrameKey(frames, frameIndex);
+  Object cacheKey(BuildContext? context) =>
+      _AnimatedSvgFrameKey(frames, frames._storageIndexAt(frameIndex));
 
   @override
   bool operator ==(Object other) =>
       other is AnimatedSvgFrameLoader &&
       identical(other.frames, frames) &&
-      other.frameIndex == frameIndex;
+      frames._storageIndexAt(other.frameIndex) == frames._storageIndexAt(frameIndex);
 
   // Deliberately the same for every frame of one animation, even though the
   // frames are not equal to each other. The renderer namespaces its image cache
@@ -235,6 +344,8 @@ class _AnimatedSvgFrameKey {
   const _AnimatedSvgFrameKey(this.frames, this.frameIndex);
 
   final AnimatedSvgFrames frames;
+
+  /// An index into the stored pictures, not into the frames.
   final int frameIndex;
 
   @override

--- a/test/animation/frames_test.dart
+++ b/test/animation/frames_test.dart
@@ -42,6 +42,88 @@ void main() {
       expect(frames.compiledByteSize, 1003);
     });
 
+    test('stores a frame that repeats only once', () {
+      final List<Uint8List> compiled = <Uint8List>[
+        frame(<int>[1, 2], <int>[9]),
+        frame(<int>[1, 2], <int>[8]),
+        frame(<int>[1, 2], <int>[9]),
+        frame(<int>[1, 2], <int>[8]),
+      ];
+      final AnimatedSvgFrames frames = AnimatedSvgFrames.fromEncodedFrames(
+        compiled,
+        duration: const Duration(seconds: 1),
+        loops: true,
+      );
+
+      expect(frames.frameCount, 4, reason: 'the timeline keeps its resolution');
+      expect(frames.distinctFrameCount, 2);
+      // Two shared bytes plus one byte for each of the two distinct frames.
+      expect(frames.compiledByteSize, 4);
+      for (var i = 0; i < compiled.length; i += 1) {
+        expect(frames.frameAt(i).buffer.asUint8List(), compiled[i], reason: 'frame $i');
+      }
+    });
+
+    test('is not animated when every frame draws the same picture', () {
+      final AnimatedSvgFrames frames = AnimatedSvgFrames.fromEncodedFrames(
+        <Uint8List>[
+          for (var i = 0; i < 60; i += 1) Uint8List.fromList(<int>[1, 2, 3]),
+        ],
+        duration: const Duration(seconds: 1),
+        loops: true,
+      );
+
+      expect(frames.frameCount, 60);
+      expect(frames.distinctFrameCount, 1);
+      expect(frames.compiledByteSize, 3, reason: 'held once, not sixty times');
+      expect(
+        frames.isAnimated,
+        isFalse,
+        reason: 'there is nothing for a ticker to do but repaint one picture',
+      );
+    });
+
+    test('leaves an animation whose frames all differ untouched', () {
+      final List<Uint8List> compiled = <Uint8List>[
+        frame(<int>[7, 7], <int>[1]),
+        frame(<int>[7, 7], <int>[2]),
+        frame(<int>[7, 7], <int>[3]),
+      ];
+      final AnimatedSvgFrames frames = AnimatedSvgFrames.fromEncodedFrames(
+        compiled,
+        duration: const Duration(seconds: 1),
+        loops: true,
+      );
+
+      expect(frames.frameCount, 3);
+      expect(frames.distinctFrameCount, 3);
+      expect(frames.isAnimated, isTrue);
+      for (var i = 0; i < compiled.length; i += 1) {
+        expect(frames.frameAt(i).buffer.asUint8List(), compiled[i], reason: 'frame $i');
+      }
+    });
+
+    test('tells frames showing one picture apart from frames showing two', () {
+      final AnimatedSvgFrames repeating = AnimatedSvgFrames.fromEncodedFrames(
+        <Uint8List>[
+          Uint8List.fromList(<int>[1]),
+          Uint8List.fromList(<int>[2]),
+          Uint8List.fromList(<int>[1]),
+        ],
+        duration: const Duration(seconds: 1),
+        loops: true,
+      );
+
+      // The widget hands the renderer one of these per frame; equal ones let it
+      // keep the picture it has already decoded.
+      expect(
+        AnimatedSvgFrameLoader(repeating, 0) == AnimatedSvgFrameLoader(repeating, 2),
+        isTrue,
+        reason: 'frames 0 and 2 are the same picture',
+      );
+      expect(AnimatedSvgFrameLoader(repeating, 0) == AnimatedSvgFrameLoader(repeating, 1), isFalse);
+    });
+
     test('costs nothing when the frames share nothing', () {
       final List<Uint8List> compiled = <Uint8List>[
         Uint8List.fromList(<int>[1, 1, 1]),


### PR DESCRIPTION
A frame was stored per sampling point. Anything that holds the document still between keyframes therefore paid for pictures it never draws, and one case paid for a ticker as well.

| | frames sampled | pictures actually drawn |
|---|---|---|
| `<set>` / discrete `calcMode`, one-second blink | 60 | **2** |
| CSS `steps(4)` slide | 60 | **4** |
| SMIL animating `d` (morphing — unsupported) | 60 | **1** |

## the `d` row is the one that matters

A document can declare an animation the renderer cannot express. Morphing `d` is the common one: it parses, it samples, and every sample comes out byte-identical. The package stored all sixty, reported `isAnimated == true`, and the widget started an `AnimationController` that repainted one unchanging picture for as long as it was on screen.

`isAnimated` now counts distinct pictures rather than sampling points, so that animation starts nothing at all.

`frameCount` keeps its meaning — the resolution the timeline was sampled at — because `frameIndexAt` depends on it for timing, and partial deduplication must not disturb *when* frames change. `distinctFrameCount` is new and says how many pictures there are.

The frame loader's equality moved to stored pictures too, so a run of identical frames is recognised as the one picture it is: the renderer neither reloads it nor caches it twice while playback sits on it.

## cost, measured against main

The case that can only lose is an animation where nothing repeats, so the whole pass is wasted work. The 450×450 banner with embedded bitmaps, 300 frames, all distinct:

| | compiled size | median compile (5 runs) | spread |
|---|---|---|---|
| `main` | 5 302 384 B | 2617 ms | 2407–2855 |
| this branch | 5 302 384 B | 2568 ms | 2381–2750 |

Identical to the byte, and the difference in time is smaller than the run-to-run spread. Frames are matched through an FNV-1a digest first — comparing each frame against every distinct frame it is *not* equal to would cost the square of the frame count in byte comparisons. A digest collision costs one failed comparison; equality is never concluded from the digest alone.

## tests

Four new ones: a frame that repeats is stored once while the timeline keeps its resolution and every index still rebuilds its own bytes; sixty identical frames report one picture, hold one picture's worth of bytes, and are not animated; an animation whose frames all differ is left alone, table and all; and two loaders for frames showing the same picture compare equal while two showing different pictures do not.

148 tests pass, analyzer clean under `--fatal-infos`.

## not verified

Only the compile side is measured. The claim that a run of identical frames now skips a reload rests on the loader equality test, not on an observation of the renderer declining to decode — the same `flutter_test` limitation as before.
