### PR TITLE
Release 0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.3.5
 
 * Keeps one copy of any frame that repeats, rather than one per sampling point.
   Frames repeat whenever the document holds still — a `<set>`, a discrete

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: svg_animate
 description: Plays SVGs that declare their own animation, in SMIL or CSS keyframes, on top of the vector_graphics renderer that flutter_svg uses.
-version: 0.3.4
+version: 0.3.5
 repository: https://github.com/Treamz/svg_animate
 issue_tracker: https://github.com/Treamz/svg_animate/issues
 


### PR DESCRIPTION
Raises the version to `0.3.5` and gives the `## Unreleased` notes that number. No other change — the diff is two lines.

Built by the `Release` workflow ([run](https://github.com/Treamz/svg_animate/actions/runs/32130548636)), which is the first run of it that got all the way through: it worked out the version, checked there was something to release and that the number was still free on pub.dev, renamed the heading, bumped the pubspec and pushed the branch.

Nothing here was written by hand, so there is nothing to review but the notes themselves. Read the 0.3.5 section of `CHANGELOG.md` as someone who will only ever see this version through it.

Then merge and tag the merge commit:

```sh
git switch main && git pull
git tag v0.3.5
git push origin v0.3.5
```
