### PR TITLE
Stop dart:io keeping the package off the web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## Unreleased
+
+* Publishes for the web again, and for WebAssembly with it. `dart:io` was
+  imported for the file loader's `File`, and an import of it anywhere in the
+  library is enough for the whole package to be analysed as not supporting the
+  web: pub.dev listed five platforms while the README promised six and described
+  what the package does on the sixth. That import now resolves to a stand-in
+  where there is no `dart:io`, the way `flutter_svg` does it. Nothing about
+  behaviour changes — a web build already compiled — and a file loader still
+  cannot be built on the web, because there are still no files there.
+* Documents `AnimationCache.maximumSizeBytes`, `currentSizeBytes` and
+  `AnimatedSvgFrames.distinctFrameCount` in the README, which went on describing
+  the cache as bounded by a count of entries alone: the model 0.3.4 replaced
+  precisely because a count says so little about how much memory is held.
+
 ## 0.3.5
 
 * Keeps one copy of any frame that repeats, rather than one per sampling point.

--- a/README.md
+++ b/README.md
@@ -189,19 +189,32 @@ of on every frame change. For a 450×450 banner carrying five embedded bitmaps
 that is 5.1 MB rather than 27.5 MB, and 1.5 ms rather than 6.8 ms to change
 frame — the same cost as an SVG that embeds nothing at all.
 
+Frames that come out of the compiler identical are also stored once. A document
+holds still more often than it looks: a `<set>`, a discrete `calcMode`, a CSS
+`steps()` timing function or a long gap between keyframes all sample to the same
+picture repeatedly, so a one-second blink at the default frame rate holds two
+pictures rather than sixty. An animation that never changes what it draws is not
+played at all, since a ticker would have nothing to do but repaint it.
+
 An animation can say what it costs rather than being guessed at:
 
 ```dart
 final AnimatedSvgFrames frames = await compileAnimatedSvg(markup);
-debugPrint('${frames.frameCount} frames, ${frames.compiledByteSize} bytes');
+debugPrint('${frames.frameCount} frames, ${frames.distinctFrameCount} distinct, '
+    '${frames.compiledByteSize} bytes');
 ```
 
 - `frameRate` (default `60`) — frames compiled per second of animation.
 - `maxFrames` (default `300`) — ceiling; longer animations are sampled at a
   lower rate rather than growing without bound.
-- `placeholderBuilder` — shown while the animation compiles.
-- `svgAnimateCache` — the shared cache of compiled animations. Lower its
-  `maximumSize` (default 10) to trade recompilation for memory.
+- `placeholderBuilder` — shown until there is a picture. The first frame is
+  compiled ahead of the rest, so it appears well before the animation is ready
+  to move.
+- `svgAnimateCache` — the shared cache of compiled animations. It is bounded by
+  `maximumSizeBytes` (default 20 MiB) as well as by `maximumSize` (default 10
+  entries), because a spinner and a banner carrying embedded bitmaps differ in
+  size by three orders of magnitude and a count alone says very little about
+  memory. `currentSizeBytes` reports what is held.
 
 On the web there are no isolates, so compilation runs on the main thread; prefer
 a lower `frameRate` for long animations there.

--- a/lib/src/animated_svg.dart
+++ b/lib/src/animated_svg.dart
@@ -1,5 +1,3 @@
-import 'dart:io' show File;
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/flutter_svg.dart' show ColorMapper, SvgTheme;
@@ -10,6 +8,7 @@ import 'animation/cache.dart';
 import 'animation/frames.dart';
 import 'color_mapper.dart';
 import 'loaders.dart';
+import 'utilities/file.dart';
 
 /// Builds the widget shown when an animation fails to load.
 typedef SvgErrorWidgetBuilder =

--- a/lib/src/loaders.dart
+++ b/lib/src/loaders.dart
@@ -1,5 +1,4 @@
 import 'dart:convert' show utf8;
-import 'dart:io' show File;
 
 import 'package:flutter/foundation.dart' hide compute;
 import 'package:flutter/services.dart';
@@ -8,6 +7,7 @@ import 'package:flutter_svg/flutter_svg.dart' show ColorMapper, DefaultSvgTheme,
 import 'package:http/http.dart' as http;
 
 import 'utilities/compute.dart';
+import 'utilities/file.dart';
 
 /// The SVG markup a loader provides, along with everything needed to compile
 /// it.

--- a/lib/src/utilities/_file_io.dart
+++ b/lib/src/utilities/_file_io.dart
@@ -1,0 +1,1 @@
+export 'dart:io' show File;

--- a/lib/src/utilities/_file_none.dart
+++ b/lib/src/utilities/_file_none.dart
@@ -1,0 +1,16 @@
+import 'dart:typed_data';
+
+/// The part of `dart:io`'s `File` that [SvgAnimateFileLoader] uses, for the web,
+/// which has no `dart:io` to take it from.
+///
+/// Nothing implements this there, so a file loader cannot be built on the web —
+/// which was already true. What it buys is that importing the library no longer
+/// drags `dart:io` into a web build, and the package can be analysed as
+/// supporting the web at all.
+abstract class File {
+  /// Where the file is.
+  String get path;
+
+  /// The whole of the file, read synchronously.
+  Uint8List readAsBytesSync();
+}

--- a/lib/src/utilities/file.dart
+++ b/lib/src/utilities/file.dart
@@ -1,0 +1,10 @@
+/// `dart:io`'s `File` where the platform has one, and a stand-in where it does
+/// not.
+///
+/// `dart:io` cannot be compiled into a web build, and importing it anywhere in
+/// the library is enough for the whole package to be analysed as not supporting
+/// the web. That is how it came to be published for five platforms while its
+/// own README promised six and described what it does on the sixth.
+library;
+
+export '_file_io.dart' if (dart.library.js_interop) '_file_none.dart';


### PR DESCRIPTION
The README claims six platforms and even describes what the package does on the sixth: "On the web there are no isolates, so compilation runs on the main thread; prefer a lower `frameRate` for long animations there."

pub.dev lists five.

```
platform:android  platform:ios  platform:windows  platform:linux  platform:macos
```

It has been published that way since 0.1.0.

## what it was

`dart:io` was imported for the file loader's `File`, in two files. An import of it anywhere in the library is enough for the whole package to be analysed as web-incompatible.

This is a labelling failure, not a build failure, and I want to be precise about that because I said the opposite before checking: `flutter build web` on the example **succeeded before this change** (37.4 s) and succeeds after it (22.1 s). Nothing was broken for anyone who tried. What it cost was being absent from pub.dev's platform filter for the one platform whose developers are most likely to already be reaching for flutter_svg.

## what changed

The import resolves through a conditional export now — `dart:io` where the platform has one, a stand-in where it does not — which is how flutter_svg keeps its own web support:

```
_file_io.dart    export 'dart:io' show File;
_file_none.dart  the two members the loader uses, for platforms without dart:io
file.dart        export '_file_io.dart' if (dart.library.js_interop) '_file_none.dart';
```

A file loader still cannot be built on the web, because there are still no files there. Nothing else about behaviour changes.

## verified

| | before | after |
|---|---|---|
| pana platform support | Supports **5** of 6 | Supports **6** of 6 |
| WASM-ready | not reported | **reported** |
| pana points | 160/160 | 160/160 |
| `flutter build web` (example) | succeeds | succeeds |
| tests | 148 pass | 148 pass |

The WASM line is a second thing that was silently lost to the same import, and neither is worth any points — this buys the two platform labels and nothing else.

## the README was also two releases behind

It still described the cache as bounded by a count of entries alone, which is exactly the model 0.3.4 replaced *because* a count says so little about memory: someone reading it would set `maximumSize = 10`, believe they had capped memory, and have capped it somewhere between 50 KB and 50 MB depending on what the app happened to show.

It now documents `maximumSizeBytes` (20 MiB), `currentSizeBytes` and `distinctFrameCount`, describes frames that repeat being stored once, and no longer implies the placeholder is shown for the whole compile — since 0.3.3 the first frame arrives long before the rest.

## note

Your uncommitted change to `example/lib/main.dart`, the one that uncomments `_ControlledSample`, went into this commit by accident and has been taken back out. It is still sitting modified in the working tree, unstaged, exactly as it was. Say the word and it can go up as its own change — the example arguably should show the controller.
