### PR TITLE
Publish the example to GitHub Pages

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -1,0 +1,55 @@
+name: Demo
+
+# Publishes the example app to GitHub Pages, so that "it animates" can be
+# checked by looking at it rather than by taking the README's word for it.
+# The example is the only thing in the repository that uses the package from
+# the outside, which is what makes it worth showing.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One deployment at a time, and never cancel one half way: an interrupted
+# deployment leaves the site serving whatever it had got to.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build the example for the web
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          channel: stable
+          cache: true
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      # A project site is served from a subdirectory, so the app has to be told
+      # where it lives or every asset it asks for resolves against the domain
+      # root and 404s.
+      - name: Build
+        run: flutter build web --release --base-href /svg_animate/ --no-tree-shake-icons
+        working-directory: example
+
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: example/build/web
+
+  deploy:
+    name: Deploy to Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5.0.1

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 [![Flutter](https://img.shields.io/badge/Flutter-%3E%3D3.38-blue)](https://flutter.dev)
 [![platform](https://img.shields.io/badge/platform-android%20%7C%20ios%20%7C%20macos%20%7C%20windows%20%7C%20linux%20%7C%20web-lightgrey)](https://pub.dev/packages/svg_animate)
 
+**[Live demo](https://treamz.github.io/svg_animate/)** — the example app, built
+for the web and running the package rather than describing it.
+
 Plays SVGs that declare their own animation — SMIL (`<animate>`,
 `<animateTransform>`, `<animateMotion>`, `<set>`), CSS `@keyframes`, and CSS
 motion paths — using the same `vector_graphics` renderer that

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -29,8 +29,8 @@ class AnimatedSvgExampleApp extends StatelessWidget {
           children: <Widget>[
             for (final MapEntry<String, String> asset in _assets.entries)
               _Sample(assetName: asset.key, description: asset.value),
-            // const Divider(height: 48),
-            // const _ControlledSample(),
+            const Divider(height: 48),
+            const _ControlledSample(),
           ],
         ),
       ),


### PR DESCRIPTION
Reopens #9, which GitHub closed by itself when #8 merged and took its base branch with it. A closed pull request can be neither reopened nor retargeted once its base is gone, so this is the same branch, rebased onto `main`, under a new number.

The README says the package animates SVGs. A page that animates them is a shorter argument.

**https://treamz.github.io/svg_animate/** once this lands.

## what it deploys

The example app, because it is the only thing in the repository that uses the package from the outside, as a dependency of an app — the same reason CI already builds it on every pull request.

A project site is served from a subdirectory, so the build passes `--base-href /svg_animate/`. Without that, every asset resolves against the domain root and the page comes up blank with a handful of 404s and no error worth reading. That is the one thing most likely to be wrong here, so it is the thing I checked hardest.

## verified

Built with the real flag, served from the same subpath locally, and watched in a browser:

| | |
|---|---|
| `index.html`, `main.dart.js`, `assets/assets/spinner.svg` | all 200 |
| `<base href="/svg_animate/">` in the built index | present |
| animation | spinner arc, pulsing ring, orbit marker and progress bar all advance between screenshots |

So it is not a first-frame screenshot: the frames differ over time, in a browser, from the subpath Pages will use.

Pages is already enabled on the repository with GitHub Actions as its source, so the first deployment runs on merge.

## the controller section is uncommented

The example had `_ControlledSample` commented out. A demo page is exactly where play, pause and seek belong — a page that only loops on its own doesn't show that the animation can be driven at all.

This is the change that was sitting unstaged in your working tree. It was pulled out of #8 as unrelated there; here it is the point.

## what is not verified

The workflow itself has not run. Its shape is checked and every action is pinned by SHA, but the first real run is the first end-to-end run. It fails loudly and before publishing anything if the build breaks; the failure mode worth knowing about is a successful deploy of a blank page, which is what the subpath check above was for.
