### PR TITLE
Say what an SVG asked for that will not happen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## Unreleased
 
+* Says what an SVG asked for that will not happen, instead of leaving it to be
+  deduced. An animation that does not play looks exactly like one that has not
+  started: a still picture and no error, whatever the reason. Every compiled
+  animation now carries `diagnostics`, and a debug build prints them the first
+  time the SVG is compiled. Five things get reported: a document with no
+  animation in it, and whether it carries a `<script>` that an editor exported
+  its animation into; an animation whose every frame drew the same picture,
+  which is what a morphing `d` does; an `<image>` pointing anywhere other than a
+  `data:` URI, which the compiler leaves out of every frame without complaining;
+  a `<filter>`, which is not drawn; and an animation sampled below the frame
+  rate asked for because `maxFrames` would not stretch that far. Set
+  `svgAnimateReportDiagnostics` to false to silence the printing.
+
 * Publishes for the web again, and for WebAssembly with it. `dart:io` was
   imported for the file loader's `File`, and an import of it anywhere in the
   library is enough for the whole package to be analysed as not supporting the

--- a/README.md
+++ b/README.md
@@ -145,6 +145,31 @@ renderer cannot do them on its own:
 | `<script>` | not run |
 | `@media`, `@supports` | skipped rather than guessed at |
 
+### When nothing moves
+
+An SVG that will not animate looks exactly like one that has not started yet: a
+still picture and no error at all. Every compiled animation carries a list of
+what it asked for that will not happen, and in debug builds an
+`AnimatedSvgPicture` prints it the first time the SVG is compiled.
+
+```dart
+final AnimatedSvgFrames frames = await compileAnimatedSvg(markup);
+for (final SvgAnimateDiagnostic diagnostic in frames.diagnostics) {
+  debugPrint('${diagnostic.kind}: ${diagnostic.message}');
+}
+```
+
+| kind | what it means |
+|---|---|
+| `noAnimation` | nothing to play. If the file also has a `<script>`, it was exported for an editor's own JavaScript player and the markup holds only the first frame; re-export it as CSS or SMIL animation |
+| `neverChanges` | an animation was declared, and every frame of it drew the same picture — something is animated that the renderer cannot express, a morphing `d` most often |
+| `unreachableImage` | an `<image>` points somewhere other than a `data:` URI; the compiler fetches nothing, so the image is left out of every frame |
+| `droppedFilter` | a `<filter>` is used, and filters are not drawn |
+| `reducedFrameRate` | the animation is longer than `maxFrames` allows at `frameRate`, so it was sampled over its whole length at a lower rate |
+
+Set `svgAnimateReportDiagnostics` to `false` to keep the printing out of a test
+that loads such a file deliberately.
+
 ## How it compares
 
 This package deliberately covers less of SVG than the alternatives, and carries

--- a/lib/src/animated_svg.dart
+++ b/lib/src/animated_svg.dart
@@ -5,6 +5,7 @@ import 'package:http/http.dart' as http;
 import 'package:vector_graphics/vector_graphics_compat.dart';
 
 import 'animation/cache.dart';
+import 'animation/diagnostics.dart';
 import 'animation/frames.dart';
 import 'color_mapper.dart';
 import 'loaders.dart';
@@ -669,6 +670,7 @@ class _AnimatedSvgPictureState extends State<AnimatedSvgPicture> with TickerProv
         key,
         () => _compile(source, loader, frameCap: widget.maxFrames),
       );
+      _reportDiagnostics(frames, loader);
       _adopt(frames, generation);
     } catch (error, stackTrace) {
       if (!mounted || generation != _loadGeneration) {
@@ -736,6 +738,23 @@ class _AnimatedSvgPictureState extends State<AnimatedSvgPicture> with TickerProv
       _frameIndex = 0;
     });
     _startPlayback(frames);
+  }
+
+  // An animation that will not play looks exactly like one that has not
+  // started yet, and neither raises anything. Saying so once, where a developer
+  // is already looking, is the difference between a puzzle and a sentence.
+  // Debug builds only, and only the first time an animation is compiled, since
+  // the cache serves every picture after that.
+  void _reportDiagnostics(AnimatedSvgFrames frames, SvgSourceLoader<Object?> loader) {
+    if (!svgAnimateReportDiagnostics || frames.diagnostics.isEmpty) {
+      return;
+    }
+    assert(() {
+      for (final SvgAnimateDiagnostic diagnostic in frames.diagnostics) {
+        debugPrint('svg_animate: $loader\n  ${diagnostic.message}');
+      }
+      return true;
+    }());
   }
 
   bool _repeats(AnimatedSvgFrames frames) => widget.repeat ?? frames.loops;

--- a/lib/src/animation/diagnostics.dart
+++ b/lib/src/animation/diagnostics.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/foundation.dart';
+import 'package:xml/xml.dart';
+
+/// What a diagnostic is about.
+///
+/// The kind is what code should branch on; [SvgAnimateDiagnostic.message] is
+/// what a person should read.
+enum SvgAnimateDiagnosticKind {
+  /// The document declares no animation this package can find.
+  noAnimation,
+
+  /// The animation was sampled, and every sample drew the same picture.
+  neverChanges,
+
+  /// An `<image>` points somewhere the compiler will not follow.
+  unreachableImage,
+
+  /// A `<filter>` is used, and the renderer beneath this package drops filters.
+  droppedFilter,
+
+  /// The animation is long enough that it was sampled below the requested rate.
+  reducedFrameRate,
+}
+
+/// Whether an [AnimatedSvgPicture] prints what an SVG asked for that will not
+/// happen, the first time that SVG is compiled.
+///
+/// Debug builds only; nothing is printed in a release build whatever this says.
+/// Set it to false for a test that deliberately loads an SVG with something
+/// wrong in it, or for an app that would rather read
+/// [AnimatedSvgFrames.diagnostics] itself.
+bool svgAnimateReportDiagnostics = true;
+
+/// Something about an SVG that this package, or the renderer beneath it, will
+/// not do — reported rather than left to be deduced.
+///
+/// An animation that does not play looks the same whatever the reason: a still
+/// picture and no error. These say which reason it was.
+@immutable
+class SvgAnimateDiagnostic {
+  /// See class doc.
+  const SvgAnimateDiagnostic(this.kind, this.message);
+
+  /// What this is about.
+  final SvgAnimateDiagnosticKind kind;
+
+  /// A sentence or two explaining what will not happen, and why.
+  final String message;
+
+  @override
+  bool operator ==(Object other) =>
+      other is SvgAnimateDiagnostic && other.kind == kind && other.message == message;
+
+  @override
+  int get hashCode => Object.hash(kind, message);
+
+  @override
+  String toString() => message;
+}
+
+/// What [document] contains that will not survive being compiled.
+///
+/// Runs over the document as it is once its animations have been resolved, so
+/// the animation elements themselves are already gone and what is left is what
+/// the compiler will actually be handed.
+List<SvgAnimateDiagnostic> diagnoseDocument(XmlDocument document, {required bool hasAnimation}) {
+  final diagnostics = <SvgAnimateDiagnostic>[];
+
+  if (!hasAnimation) {
+    diagnostics.add(
+      SvgAnimateDiagnostic(
+        SvgAnimateDiagnosticKind.noAnimation,
+        _containsScript(document)
+            ? 'This SVG declares no SMIL or CSS animation, and carries a <script> '
+                  'element. Editors that export for their own JavaScript player put the '
+                  'animation in that script and leave the markup holding the first frame, '
+                  'which is all there is here to draw. Re-exporting as CSS or SMIL '
+                  'animation puts the animation in the file itself.'
+            : 'This SVG declares no SMIL or CSS animation, so there is a single frame '
+                  'to draw and nothing to play.',
+      ),
+    );
+  }
+
+  for (final XmlElement image in document.descendantElements) {
+    if (image.name.local != 'image') {
+      continue;
+    }
+    final String? href = _href(image);
+    if (href == null || href.startsWith('data:')) {
+      continue;
+    }
+    diagnostics.add(
+      SvgAnimateDiagnostic(
+        SvgAnimateDiagnosticKind.unreachableImage,
+        'An <image> points at "${_short(href)}". The compiler reads image data only '
+        'from a data: URI and fetches nothing, so this image is left out of every '
+        'frame without an error. Embed it in the SVG to have it drawn.',
+      ),
+    );
+  }
+
+  final int filters = _filterCount(document);
+  if (filters > 0) {
+    diagnostics.add(
+      SvgAnimateDiagnostic(
+        SvgAnimateDiagnosticKind.droppedFilter,
+        'This SVG uses $filters filter${filters == 1 ? '' : 's'}. vector_graphics, the '
+        'renderer this package draws through, does not implement <filter>: the shapes '
+        'are drawn and the blurs, glows and drop shadows are not. Nothing in this '
+        'package can add them.',
+      ),
+    );
+  }
+
+  return diagnostics;
+}
+
+bool _containsScript(XmlDocument document) =>
+    document.descendantElements.any((XmlElement e) => e.name.local == 'script');
+
+/// Counts filters that are actually reached, rather than every `<filter>`
+/// defined, since a definition nothing refers to costs nothing.
+int _filterCount(XmlDocument document) {
+  final used = <String>{};
+  for (final XmlElement element in document.descendantElements) {
+    final String? attribute = element.getAttribute('filter');
+    if (attribute != null) {
+      _collectReferences(attribute, used);
+    }
+    final String? style = element.getAttribute('style');
+    if (style != null) {
+      // Only the filter declaration: a style carries `fill: url(#gradient)`
+      // far more often than it carries a filter, and a gradient is drawn.
+      for (final RegExpMatch match in _filterDeclaration.allMatches(style)) {
+        _collectReferences(match.group(1)!, used);
+      }
+    }
+  }
+  return used.length;
+}
+
+void _collectReferences(String value, Set<String> into) {
+  for (final RegExpMatch match in _urlReference.allMatches(value)) {
+    into.add(match.group(1)!);
+  }
+}
+
+final RegExp _urlReference = RegExp(r'url\(\s*#([^)\s]+)\s*\)');
+final RegExp _filterDeclaration = RegExp(r'(?:^|;)\s*filter\s*:\s*([^;]+)', caseSensitive: false);
+
+String? _href(XmlElement element) {
+  for (final XmlAttribute attribute in element.attributes) {
+    if (attribute.name.local == 'href') {
+      return attribute.value;
+    }
+  }
+  return null;
+}
+
+String _short(String value) => value.length <= 60 ? value : '${value.substring(0, 57)}...';

--- a/lib/src/animation/document.dart
+++ b/lib/src/animation/document.dart
@@ -1,5 +1,7 @@
 import 'package:xml/xml.dart';
 
+import 'diagnostics.dart';
+
 import 'animation.dart';
 import 'css.dart';
 import 'css_animations.dart';
@@ -137,6 +139,13 @@ class AnimatedSvgDocument {
 
   final XmlDocument _document;
   final List<_AnimationTarget> _targets;
+
+  /// What this document contains that will not survive being compiled.
+  ///
+  /// Read after parsing, when the animation elements have been resolved away
+  /// and what is left is what the compiler will be handed.
+  List<SvgAnimateDiagnostic> get diagnostics =>
+      diagnoseDocument(_document, hasAnimation: _targets.isNotEmpty);
 
   /// How long one full loop of the document takes.
   ///

--- a/lib/src/animation/frames.dart
+++ b/lib/src/animation/frames.dart
@@ -4,6 +4,7 @@ import 'package:vector_graphics/vector_graphics.dart';
 import 'package:vector_graphics_compiler/vector_graphics_compiler.dart' as vg;
 
 import '../utilities/compute.dart';
+import 'diagnostics.dart';
 import 'document.dart';
 
 /// The default number of frames compiled per second of animation.
@@ -36,6 +37,7 @@ class AnimatedSvgFrames {
     required List<int>? storage,
     required this.duration,
     required this.loops,
+    required this.diagnostics,
   }) : _shared = shared,
        _tails = tails,
        _storage = storage;
@@ -46,6 +48,7 @@ class AnimatedSvgFrames {
     List<Uint8List> frames, {
     required Duration duration,
     required bool loops,
+    List<SvgAnimateDiagnostic> diagnostics = const <SvgAnimateDiagnostic>[],
   }) {
     assert(frames.isNotEmpty);
     final int shared = _sharedPrefixLength(frames);
@@ -57,6 +60,7 @@ class AnimatedSvgFrames {
       storage: distinct.storage,
       duration: duration,
       loops: loops,
+      diagnostics: diagnostics,
     );
   }
 
@@ -73,6 +77,12 @@ class AnimatedSvgFrames {
 
   /// Whether playback should restart after the last frame.
   final bool loops;
+
+  /// What this SVG asks for that will not happen, if anything.
+  ///
+  /// An animation that does not play looks the same whatever the reason, so
+  /// these say which reason it was. Empty for an SVG with nothing to report.
+  final List<SvgAnimateDiagnostic> diagnostics;
 
   /// How many frames the animation was sampled at.
   ///
@@ -116,6 +126,18 @@ class AnimatedSvgFrames {
       ..setRange(_shared.length, _shared.length + tail.length, tail);
     return frame.buffer.asByteData();
   }
+
+  /// The same frames, carrying [diagnostics] in place of the ones they hold.
+  ///
+  /// Shares the stored frames rather than splitting and comparing them again.
+  AnimatedSvgFrames _withDiagnostics(List<SvgAnimateDiagnostic> diagnostics) => AnimatedSvgFrames._(
+    shared: _shared,
+    tails: _tails,
+    storage: _storage,
+    duration: duration,
+    loops: loops,
+    diagnostics: diagnostics,
+  );
 
   /// The frame to show at [progress] through the animation, from 0.0 to 1.0.
   int frameIndexAt(double progress) {
@@ -255,6 +277,10 @@ Future<AnimatedSvgFrames> compileAnimatedSvgFrames(
       final document = AnimatedSvgDocument.parse(source);
       final Duration duration = document.duration;
       final int frameCount = _frameCount(duration, frameRate, maxFrames);
+      final diagnostics = <SvgAnimateDiagnostic>[
+        ...document.diagnostics,
+        ..._samplingDiagnostics(duration, frameRate, frameCount),
+      ];
       final frames = <Uint8List>[
         for (var index = 0; index < frameCount; index += 1)
           vg.encodeSvg(
@@ -267,11 +293,57 @@ Future<AnimatedSvgFrames> compileAnimatedSvgFrames(
             enableOverdrawOptimizer: false,
           ),
       ];
-      return AnimatedSvgFrames.fromEncodedFrames(frames, duration: duration, loops: document.loops);
+      final AnimatedSvgFrames compiled = AnimatedSvgFrames.fromEncodedFrames(
+        frames,
+        duration: duration,
+        loops: document.loops,
+        diagnostics: diagnostics,
+      );
+      // Only knowable once the frames exist: the document declared an animation
+      // and every sample of it came out as the same picture. Reported by
+      // rebuilding the wrapper rather than the frames, which have already been
+      // split and compared and would otherwise be split and compared again.
+      if (compiled.frameCount > 1 && compiled.distinctFrameCount == 1) {
+        return compiled._withDiagnostics(<SvgAnimateDiagnostic>[
+          ...diagnostics,
+          const SvgAnimateDiagnostic(
+            SvgAnimateDiagnosticKind.neverChanges,
+            'This SVG declares an animation, and every frame it was sampled at drew '
+            'exactly the same picture. Something is being animated that the '
+            'renderer cannot express — a morphing "d" is the usual one — so the '
+            'values change and nothing about the drawing does. It is treated as a '
+            'still picture and no ticker is started.',
+          ),
+        ]);
+      }
+      return compiled;
     },
     source,
     debugLabel: 'Compile animated SVG',
   );
+}
+
+/// Whether [maxFrames] forced a lower sampling rate than [frameRate] asked for.
+List<SvgAnimateDiagnostic> _samplingDiagnostics(
+  Duration duration,
+  double frameRate,
+  int frameCount,
+) {
+  final double seconds = duration.inMicroseconds / Duration.microsecondsPerSecond;
+  if (seconds <= 0 || (seconds * frameRate).round() <= frameCount) {
+    return const <SvgAnimateDiagnostic>[];
+  }
+  final double effective = frameCount / seconds;
+  return <SvgAnimateDiagnostic>[
+    SvgAnimateDiagnostic(
+      SvgAnimateDiagnosticKind.reducedFrameRate,
+      'This animation runs for ${seconds.toStringAsFixed(2)} s, which at '
+      '${frameRate.toStringAsFixed(0)} fps is more frames than maxFrames allows. It was '
+      'sampled at ${effective.toStringAsFixed(1)} fps instead, over its whole length, so '
+      'it plays complete but less smoothly. Raise maxFrames to spend memory on '
+      'smoothness.',
+    ),
+  ];
 }
 
 int _frameCount(Duration duration, double frameRate, int maxFrames) {

--- a/lib/svg_animate.dart
+++ b/lib/svg_animate.dart
@@ -12,6 +12,8 @@ library;
 
 export 'src/animated_svg.dart';
 export 'src/animation/cache.dart' show AnimationCache, svgAnimateCache;
+export 'src/animation/diagnostics.dart'
+    show SvgAnimateDiagnostic, SvgAnimateDiagnosticKind, svgAnimateReportDiagnostics;
 export 'src/animation/frames.dart'
     show AnimatedSvgFrames, defaultAnimationFrameRate, defaultMaxAnimationFrames;
 export 'src/compile.dart' show compileAnimatedSvg;

--- a/test/animation/diagnostics_test.dart
+++ b/test/animation/diagnostics_test.dart
@@ -1,0 +1,131 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:svg_animate/svg_animate.dart';
+
+Future<List<SvgAnimateDiagnostic>> diagnose(String svg, {int maxFrames = 300}) async {
+  final AnimatedSvgFrames frames = await compileAnimatedSvg(svg, maxFrames: maxFrames);
+  return frames.diagnostics;
+}
+
+Set<SvgAnimateDiagnosticKind> kinds(List<SvgAnimateDiagnostic> diagnostics) =>
+    diagnostics.map((SvgAnimateDiagnostic d) => d.kind).toSet();
+
+const String movingRect = '''
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="10" height="10" fill="#f00">
+    <animate attributeName="x" dur="1s" values="0;90" repeatCount="indefinite"/>
+  </rect>
+</svg>''';
+
+void main() {
+  group('diagnostics', () {
+    test('an animation that works reports nothing', () async {
+      expect(await diagnose(movingRect), isEmpty);
+    });
+
+    test('names the script when a document has one and no animation', () async {
+      final List<SvgAnimateDiagnostic> found = await diagnose('''
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="10" height="10" fill="#f00"/>
+  <script>window.__PLAYER__ = {};</script>
+</svg>''');
+
+      expect(kinds(found), <SvgAnimateDiagnosticKind>{SvgAnimateDiagnosticKind.noAnimation});
+      expect(found.single.message, contains('<script>'));
+    });
+
+    test('does not blame a script that is not there', () async {
+      final List<SvgAnimateDiagnostic> found = await diagnose(
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><rect width="5" height="5"/></svg>',
+      );
+
+      expect(kinds(found), <SvgAnimateDiagnosticKind>{SvgAnimateDiagnosticKind.noAnimation});
+      expect(found.single.message, isNot(contains('script')));
+    });
+
+    test('reports an image the compiler will not fetch, and names it', () async {
+      final List<SvgAnimateDiagnostic> found = await diagnose('''
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 100 100">
+  <rect width="10" height="10" fill="#f00">
+    <animate attributeName="x" dur="1s" values="0;90" repeatCount="indefinite"/>
+  </rect>
+  <image width="100" height="100" xlink:href="https://example.com/photo.jpeg"/>
+</svg>''');
+
+      expect(kinds(found), <SvgAnimateDiagnosticKind>{SvgAnimateDiagnosticKind.unreachableImage});
+      expect(found.single.message, contains('https://example.com/photo.jpeg'));
+    });
+
+    test('says nothing about an image that is embedded', () async {
+      final List<SvgAnimateDiagnostic> found = await diagnose('''
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="10" height="10" fill="#f00">
+    <animate attributeName="x" dur="1s" values="0;90" repeatCount="indefinite"/>
+  </rect>
+  <image width="1" height="1" href="data:image/png;base64,iVBORw0KGgo="/>
+</svg>''');
+
+      expect(found, isEmpty);
+    });
+
+    test('reports a filter that is used', () async {
+      final List<SvgAnimateDiagnostic> found = await diagnose('''
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <defs><filter id="b"><feGaussianBlur stdDeviation="4"/></filter></defs>
+  <rect width="50" height="50" fill="#f00" filter="url(#b)">
+    <animate attributeName="x" dur="1s" values="0;40" repeatCount="indefinite"/>
+  </rect>
+</svg>''');
+
+      expect(kinds(found), <SvgAnimateDiagnosticKind>{SvgAnimateDiagnosticKind.droppedFilter});
+      expect(found.single.message, contains('1 filter'));
+    });
+
+    test('does not mistake a gradient in a style for a filter', () async {
+      // `fill: url(#…)` is far more common than a filter, and gradients draw.
+      final List<SvgAnimateDiagnostic> found = await diagnose('''
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <defs>
+    <linearGradient id="g"><stop offset="0%" stop-color="#f00"/></linearGradient>
+  </defs>
+  <rect width="50" height="50" style="fill: url(#g)">
+    <animate attributeName="x" dur="1s" values="0;40" repeatCount="indefinite"/>
+  </rect>
+</svg>''');
+
+      expect(found, isEmpty);
+    });
+
+    test('reports an animation whose every frame draws the same picture', () async {
+      final List<SvgAnimateDiagnostic> found = await diagnose('''
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <path d="M0 0 L10 0 L10 10 Z" fill="#f00">
+    <animate attributeName="d" dur="1s" repeatCount="indefinite"
+             values="M0 0 L10 0 L10 10 Z;M0 0 L90 0 L90 90 Z"/>
+  </path>
+</svg>''');
+
+      expect(kinds(found), contains(SvgAnimateDiagnosticKind.neverChanges));
+      expect(found.last.message, contains('"d"'));
+    });
+
+    test('reports being sampled below the requested rate, and says the rate', () async {
+      // Two seconds at 60 fps wants 120 frames; 30 are allowed.
+      final List<SvgAnimateDiagnostic> found = await diagnose('''
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="10" height="10" fill="#f00">
+    <animate attributeName="x" dur="2s" values="0;90" repeatCount="indefinite"/>
+  </rect>
+</svg>''', maxFrames: 30);
+
+      expect(kinds(found), <SvgAnimateDiagnosticKind>{SvgAnimateDiagnosticKind.reducedFrameRate});
+      expect(found.single.message, contains('15.0 fps'));
+    });
+
+    test('says nothing about the rate when every frame asked for was compiled', () async {
+      expect(
+        kinds(await diagnose(movingRect)),
+        isNot(contains(SvgAnimateDiagnosticKind.reducedFrameRate)),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Three times in one week a file "did not work" and the only way to find out why was to read the source of `vector_graphics_compiler`. An SVG that will not animate looks exactly like one that has not started yet: a still picture, no error, nothing in the log.

Every compiled animation now carries `diagnostics`, and a debug build prints them the first time that SVG is compiled — where somebody is already looking.

## the five kinds

Each of these is something that actually happened to a real file, not a guess at what might.

| kind | the case it came from |
|---|---|
| `noAnimation` | a SVGator export for its own JavaScript player: the animation lives in a `<script>` and the markup holds the first frame. The message says so when a `<script>` is present, and does not when it is not |
| `neverChanges` | a SMIL animation of `d`. It parses, it samples, and all sixty frames come out byte-identical |
| `unreachableImage` | five `<image>` elements pointing at `https://cdn.svgator.com/…`. The compiler reads only `data:` URIs and fetches nothing, so they are left out of every frame in silence |
| `droppedFilter` | filters are not drawn by the renderer beneath this package |
| `reducedFrameRate` | an animation longer than `maxFrames` allows at the requested rate |

The last two of those are derived from the result rather than from a list of things known to be unsupported, so they cannot go stale against a renderer that changes underneath.

## the bug I found before the tests did

Filters are counted by *reference*, not by definition, and only the `filter` declaration inside a `style` is read.

The first version scanned the whole `style` attribute for `url(#…)`, which counts `fill: url(#gradient)` as a filter. Gradients are far more common than filters and they draw correctly. There is a test for it now.

## verified against real files, not only fixtures

The 450×450 SVGator banner:

```
[droppedFilter]     This SVG uses 2 filters…
[reducedFrameRate]  runs for 6.00 s, which at 60 fps is more frames than
                    maxFrames allows. It was sampled at 50.0 fps instead…
```

The second line is the interesting one: that banner has been playing at 50 fps rather than 60 for the whole time we have been working on it, and nothing anywhere said so.

`doc/demo.svg` and all four example assets report nothing, so a file that works stays quiet.

Ten new tests, 158 total, analyzer clean.

## also

`compileAnimatedSvgFrames` no longer builds the frames twice when it has a `neverChanges` diagnostic to attach — the first version re-split and re-compared every frame to add one line of text.

## not verified

That the printing actually appears in a running app. It sits behind an `assert` block and `svgAnimateReportDiagnostics`, both of which are covered by reading rather than by a test; `flutter_test` captures `debugPrint` in a way that makes asserting on it more brittle than the thing being asserted.
