### PR TITLE
Release 0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.3.6
 
 * Says what an SVG asked for that will not happen, instead of leaving it to be
   deduced. An animation that does not play looks exactly like one that has not

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: svg_animate
 description: Plays SVGs that declare their own animation, in SMIL or CSS keyframes, on top of the vector_graphics renderer that flutter_svg uses.
-version: 0.3.5
+version: 0.3.6
 repository: https://github.com/Treamz/svg_animate
 issue_tracker: https://github.com/Treamz/svg_animate/issues
 


### PR DESCRIPTION
Raises the version to `0.3.6` and gives the `## Unreleased` notes that number. Two lines changed.

Built by the `Release` workflow ([run](https://github.com/Treamz/svg_animate/actions/runs/33972868641)).

Three things ship in this one:

- the package is published for the web and for WebAssembly again, after `dart:io` had kept it listed for five platforms while the README promised six;
- compiled animations say what an SVG asked for that will not happen, rather than leaving a still picture and no error to be deduced;
- the README documents `maximumSizeBytes`, `currentSizeBytes` and `distinctFrameCount`, which it had gone two releases without.

All additive, so `patch` is the right step under the versioning rule in CONTRIBUTING: nothing exported changes meaning.

Read the 0.3.6 section as someone who will only ever see this version through it. Then merge and tag the merge commit:

```sh
git switch main && git pull
git tag v0.3.6
git push origin v0.3.6
```
