### PR TITLE
Keep a corner radius inside the rect it rounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Unreleased
+
+* Keeps a rounded rectangle's corner radius inside the size it is drawn at. SVG
+  clamps a radius larger than half the side it rounds down to half that side, so
+  a rect of zero width draws nothing; `vector_graphics_compiler` uses the radius
+  as authored, and the two rounded ends cross over one another into a bow tie.
+  Anything that grows a rounded bar from nothing showed it — including the
+  progress bar in this package's own example and in its README — for as long as
+  the bar was narrower than twice its radius. Worth fixing in flutter/packages
+  too, where it would also fix still SVGs drawn through `flutter_svg`; the code
+  here can only reach what it compiles itself.
+
 ## 0.3.6
 
 * Says what an SVG asked for that will not happen, instead of leaving it to be

--- a/lib/src/animation/document.dart
+++ b/lib/src/animation/document.dart
@@ -1,15 +1,92 @@
-import 'package:xml/xml.dart';
+import 'dart:math' as math;
 
-import 'diagnostics.dart';
+import 'package:xml/xml.dart';
 
 import 'animation.dart';
 import 'css.dart';
 import 'css_animations.dart';
+import 'diagnostics.dart';
 import 'expand_use.dart';
 import 'offset_path.dart';
 import 'parsed_animation.dart';
 import 'smil_parser.dart';
 import 'values.dart';
+
+/// A `<rect>` whose corner radius has to be kept within the size it is drawn at.
+///
+/// SVG clamps a corner radius larger than half the side it rounds down to half
+/// that side, so a rect of zero width has square corners and draws nothing.
+/// `vector_graphics_compiler` hands `rx` and `ry` to `addRRect` exactly as
+/// authored — `_Paths.rect` in `svg/parser.dart` — so the rounded ends cross
+/// over one another and a zero-width rect draws as a bow tie instead of as
+/// nothing at all.
+///
+/// This is worth fixing in flutter/packages rather than only here: it is a
+/// couple of lines in that parser, it is a plain spec violation, and it would
+/// fix the same artefact for still SVGs drawn through `flutter_svg`, which this
+/// package cannot reach. Clamping here only covers documents it compiles.
+///
+/// The radius is always recomputed from the authored one rather than from
+/// whatever was written last: a radius too large at one width is right again at
+/// the next, and folding the clamp back into the source would square the
+/// corners for the rest of the animation.
+class _RoundedRect {
+  _RoundedRect(this.element, this.rx, this.ry);
+
+  /// The rect, if [element] is one with a corner radius to look after.
+  static _RoundedRect? of(XmlElement element) {
+    if (element.name.local != 'rect') {
+      return null;
+    }
+    final double? rx = _numericAttribute(element, 'rx');
+    final double? ry = _numericAttribute(element, 'ry');
+    if (rx == null && ry == null) {
+      return null;
+    }
+    // Either one on its own stands for both.
+    return _RoundedRect(element, rx ?? ry!, ry ?? rx!);
+  }
+
+  final XmlElement element;
+
+  /// As authored, never as last written.
+  final double rx;
+  final double ry;
+
+  /// Brings the radius within the size the rect currently has.
+  void clamp() {
+    final double? width = _numericAttribute(element, 'width');
+    final double? height = _numericAttribute(element, 'height');
+    if (width == null || height == null) {
+      // A length this cannot read on its own, a percentage most likely.
+      // Leaving the radius alone is wrong less often than guessing at the size.
+      return;
+    }
+    final double x = math.min(rx, math.max(width, 0) / 2);
+    final double y = math.min(ry, math.max(height, 0) / 2);
+    if (x <= 0 || y <= 0) {
+      // A corner needs both radii to be rounded at all, so either one reaching
+      // zero squares it. Removing them takes the compiler down its plain
+      // rectangle path rather than asking it to round by nothing.
+      element.removeAttribute('rx');
+      element.removeAttribute('ry');
+      return;
+    }
+    element.setAttribute('rx', formatSvgNumber(x));
+    element.setAttribute('ry', formatSvgNumber(y));
+  }
+}
+
+/// The value of [name] on [element] as a plain number, or null for anything
+/// carrying units, a percentage, or nothing at all.
+double? _numericAttribute(XmlElement element, String name) {
+  final String? value = element.getAttribute(name);
+  if (value == null) {
+    return null;
+  }
+  final double? parsed = double.tryParse(value.trim());
+  return parsed != null && parsed.isFinite ? parsed : null;
+}
 
 /// The longest loop this package will build for a document whose animations
 /// repeat indefinitely.
@@ -27,7 +104,13 @@ const Duration maxLoopDuration = Duration(seconds: 60);
 /// Sampling produces plain SVG markup with no animation elements, so the result
 /// can be handed to the ordinary vector_graphics compiler.
 class AnimatedSvgDocument {
-  AnimatedSvgDocument._(this._document, this._targets, this.duration, this.loops);
+  AnimatedSvgDocument._(
+    this._document,
+    this._targets,
+    this._roundedRects,
+    this.duration,
+    this.loops,
+  );
 
   /// Parses [source] and resolves the animations it declares.
   ///
@@ -133,12 +216,29 @@ class AnimatedSvgDocument {
       }
     }
 
+    // A rounded rect whose size changes has to have its radius kept inside that
+    // size for every frame; one whose size is fixed only needs it once.
+    final roundedRects = <_RoundedRect>[];
+    for (final XmlElement element in document.descendantElements) {
+      final _RoundedRect? rect = _RoundedRect.of(element);
+      if (rect == null) {
+        continue;
+      }
+      if (targetsByKey.containsKey((element, 'width')) ||
+          targetsByKey.containsKey((element, 'height'))) {
+        roundedRects.add(rect);
+      } else {
+        rect.clamp();
+      }
+    }
+
     final _DocumentTiming timing = _documentTiming(targets);
-    return AnimatedSvgDocument._(document, targets, timing.duration, timing.loops);
+    return AnimatedSvgDocument._(document, targets, roundedRects, timing.duration, timing.loops);
   }
 
   final XmlDocument _document;
   final List<_AnimationTarget> _targets;
+  final List<_RoundedRect> _roundedRects;
 
   /// What this document contains that will not survive being compiled.
   ///
@@ -167,6 +267,9 @@ class AnimatedSvgDocument {
   String sampleAt(Duration time) {
     for (final _AnimationTarget target in _targets) {
       target.applyAt(time);
+    }
+    for (final _RoundedRect rect in _roundedRects) {
+      rect.clamp();
     }
     return _document.toXmlString();
   }

--- a/test/animation/rounded_rect_test.dart
+++ b/test/animation/rounded_rect_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:svg_animate/src/animation/document.dart';
+
+/// The rect the progress bar in `example/assets/progress.svg` is built from:
+/// a corner radius of 4 on a bar that grows from nothing.
+const String growingBar = '''
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 24">
+  <rect x="2" y="8" width="0" height="8" rx="4" fill="#42a5f5">
+    <animate attributeName="width" from="0" to="116" dur="2s" fill="freeze"/>
+  </rect>
+</svg>''';
+
+String at(String svg, int milliseconds) =>
+    AnimatedSvgDocument.parse(svg).sampleAt(Duration(milliseconds: milliseconds));
+
+/// Samples one document at several times, which matters because the radius has
+/// to be worked out afresh each time rather than folded into the source.
+List<String> over(String svg, List<int> milliseconds) {
+  final AnimatedSvgDocument document = AnimatedSvgDocument.parse(svg);
+  return <String>[
+    for (final int time in milliseconds) document.sampleAt(Duration(milliseconds: time)),
+  ];
+}
+
+void main() {
+  group('a corner radius larger than the side it rounds', () {
+    test('is gone entirely while the rect has no width', () {
+      final String frame = at(growingBar, 0);
+
+      expect(frame, contains('width="0"'));
+      expect(frame, isNot(contains('rx=')), reason: 'a corner with no width is not rounded');
+      expect(frame, isNot(contains('ry=')));
+    });
+
+    test('is held to half the width while the rect is narrow', () {
+      // Half of 8 is 4, so a bar 8 wide is the last one still clamped.
+      final String frame = at('''
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 24">
+  <rect x="2" y="8" width="3" height="8" rx="4" fill="#42a5f5">
+    <animate attributeName="width" from="3" to="3" dur="2s" fill="freeze"/>
+  </rect>
+</svg>''', 0);
+
+      expect(frame, contains('rx="1.5"'), reason: 'half of the width');
+      expect(frame, contains('ry="4"'), reason: 'half of the height, so unchanged');
+    });
+
+    test('comes back once the rect is wide enough for it', () {
+      // The trap: clamping into the source would square the corners for good.
+      final List<String> frames = over(growingBar, <int>[0, 2000]);
+
+      expect(frames.first, isNot(contains('rx=')));
+      expect(frames.last, contains('width="116"'));
+      expect(frames.last, contains('rx="4"'), reason: 'the authored radius, not the clamped one');
+    });
+
+    test('is clamped once for a rect that does not change size', () {
+      final String frame = at('''
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 24">
+  <rect x="0" y="0" width="4" height="20" rx="6" fill="#000"/>
+  <circle cx="5" cy="5" r="2" fill="#f00">
+    <animate attributeName="r" from="2" to="4" dur="1s" fill="freeze"/>
+  </circle>
+</svg>''', 0);
+
+      expect(frame, contains('rx="2"'), reason: 'half of a width that never moves');
+      expect(frame, contains('ry="6"'));
+    });
+
+    test('takes ry from rx when only one of them is written', () {
+      final String frame = at('''
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 24">
+  <rect x="0" y="0" width="20" height="3" ry="5" fill="#000"/>
+</svg>''', 0);
+
+      // ry stands for both, so the height clamps it to 1.5 and the width leaves
+      // the horizontal radius alone.
+      expect(frame, contains('rx="5"'));
+      expect(frame, contains('ry="1.5"'));
+    });
+
+    test('is left alone when the size is not a plain number', () {
+      // Guessing at what a percentage resolves to would be wrong more often
+      // than doing nothing.
+      final String frame = at('''
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 24">
+  <rect x="0" y="0" width="2%" height="8" rx="4" fill="#000"/>
+</svg>''', 0);
+
+      expect(frame, contains('rx="4"'));
+    });
+
+    test('leaves a rect with no radius as it found it', () {
+      final String frame = at('''
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 24">
+  <rect x="0" y="0" width="0" height="8" fill="#000"/>
+</svg>''', 0);
+
+      expect(frame, isNot(contains('rx=')));
+      expect(frame, isNot(contains('ry=')));
+    });
+  });
+}


### PR DESCRIPTION
The progress bar draws a blue bow tie at its left edge for the first fraction of a second. It is in this package's own example and in the image at the top of its README.

## why

SVG clamps a corner radius larger than half the side it rounds down to half that side, so a rect of zero width has square corners and draws nothing. `vector_graphics_compiler` hands `rx` and `ry` to `addRRect` exactly as authored, in `_Paths.rect`, so the two rounded ends cross over one another.

It lasts while `width < 2 * rx` — eight units out of a hundred and sixteen on the example, about 1.5% of the animation. That is why it took a screenshot of the very first frames to catch.

## where this is fixed, and where it should be

Here, because this package writes the markup for every frame and a document it emits should be valid SVG.

Not the better place, though. A couple of lines in that parser would fix it for **still** SVGs drawn through `flutter_svg` too, which nothing here can reach: `<rect width="2" rx="4"/>` in a plain `SvgPicture` has the same bow tie today. There is a comment on the class saying so, as requested.

## the part that is easy to get wrong

The radius is recomputed from the **authored** value every frame, never from the last one written. Folding the clamp back into the document would square the corners for the rest of the animation, because a radius too large at one width is correct again at the next. There is a test for exactly that.

A rect whose size never changes is clamped once at parse rather than per frame. A width that is not a plain number — a percentage — is left alone; guessing at what it resolves to would be wrong more often than doing nothing.

## a bug I put in and took out again

The first version removed the radius only when **both** clamped radii reached zero. On a zero-width, eight-high rect that leaves `rx="0"` beside `ry="4"`: half-clamped, still asking for an arc that cannot exist. A corner needs both radii to be rounded at all, so either one reaching zero now removes both.

I found it by printing the emitted markup across the animation rather than by reading my own code back.

## verified by rendering, not by reasoning

Frame 0 through the actual widget, with and without the change:

| | |
|---|---|
| before | blue bow tie at the left edge |
| after | nothing but the grey track, as a browser draws it |

Seven tests cover the clamping itself. 165 tests total, analyzer clean.
