### PR TITLE
Release 0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.3.7
 
 * Keeps a rounded rectangle's corner radius inside the size it is drawn at. SVG
   clamps a radius larger than half the side it rounds down to half that side, so

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: svg_animate
 description: Plays SVGs that declare their own animation, in SMIL or CSS keyframes, on top of the vector_graphics renderer that flutter_svg uses.
-version: 0.3.6
+version: 0.3.7
 repository: https://github.com/Treamz/svg_animate
 issue_tracker: https://github.com/Treamz/svg_animate/issues
 


### PR DESCRIPTION
Raises the version to `0.3.7` and gives the `## Unreleased` note that number. Two lines changed.

Built by the `Release` workflow ([run](https://github.com/Treamz/svg_animate/actions/runs/34690753225)).

One thing ships: a rounded rectangle's corner radius is kept inside the size it is drawn at, so a bar that grows from nothing no longer draws a bow tie at its left edge while it is narrower than twice its radius. It was visible in this package's own example and on the demo page.

Additive and a fix, nothing exported changes meaning, so `patch`.

Since #14 there are also golden tests standing behind it: the two frames that showed the artefact are stored images now, and they were checked against a build with the clamping disabled to make sure they fail for that reason and nothing else.

Read the 0.3.7 section as someone who will only ever see this version through it. Then merge and tag the merge commit:

```sh
git switch main && git pull
git tag v0.3.7
git push origin v0.3.7
```
