### PR TITLE
Compile an animation before anything shows it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Unreleased
+
+* Adds `precacheAnimatedSvg`, which compiles an animation into the shared cache
+  before anything shows it. Compiling is the expensive part of drawing an
+  animated SVG and it happened when the picture was first built, so a large
+  document showed a placeholder, then a still first frame, and only then moved.
+  There was no way to do that work on the screen before, because the key the
+  picture looks an animation up under was private and `compileAnimatedSvg`
+  compiled without caching. `AnimatedSvgCacheKey` is exported with it, which also
+  makes `AnimationCache`'s `[]` and `evict` usable: both take a key, and until
+  now there was no way to build one.
+
 ## 0.3.7
 
 * Keeps a rounded rectangle's corner radius inside the size it is drawn at. SVG

--- a/README.md
+++ b/README.md
@@ -247,6 +247,25 @@ debugPrint('${frames.frameCount} frames, ${frames.distinctFrameCount} distinct, 
 On the web there are no isolates, so compilation runs on the main thread; prefer
 a lower `frameRate` for long animations there.
 
+Compiling is what the wait is made of, and it can be done before anything is
+waiting. `precacheAnimatedSvg` compiles an animation into the same cache the
+picture reads, so the picture is there the moment the widget is:
+
+```dart
+@override
+void didChangeDependencies() {
+  super.didChangeDependencies();
+  precacheAnimatedSvg(const SvgAnimateAssetLoader('assets/intro.svg'), context);
+}
+```
+
+Pass the context the picture will be built under, since that is what resolves an
+enclosing `DefaultSvgTheme` and `DefaultAssetBundle`, and pass the same
+`frameRate` and `maxFrames`: an animation compiled at one frame rate is not the
+one compiled at another, and they are cached apart. It returns the compiled
+frames, so it can also answer what an animation costs before deciding anything
+about it.
+
 ## Contributing
 
 Development setup and the release process are in

--- a/lib/src/animated_svg.dart
+++ b/lib/src/animated_svg.dart
@@ -545,29 +545,6 @@ class AnimatedSvgPicture extends StatefulWidget {
   }
 }
 
-/// The cache key for a compiled animation.
-///
-/// The frame rate and frame ceiling are part of the key because they change the
-/// frames that get compiled, not just how they are played back.
-@immutable
-class _AnimationCacheKey {
-  const _AnimationCacheKey(this.loaderKey, this.frameRate, this.maxFrames);
-
-  final Object loaderKey;
-  final double frameRate;
-  final int maxFrames;
-
-  @override
-  bool operator ==(Object other) =>
-      other is _AnimationCacheKey &&
-      other.loaderKey == loaderKey &&
-      other.frameRate == frameRate &&
-      other.maxFrames == maxFrames;
-
-  @override
-  int get hashCode => Object.hash(loaderKey, frameRate, maxFrames);
-}
-
 // Uses [TickerProviderStateMixin] rather than the single ticker variant because
 // a new playback controller, and so a new ticker, is created every time the
 // animation is recompiled.
@@ -632,7 +609,7 @@ class _AnimatedSvgPictureState extends State<AnimatedSvgPicture> with TickerProv
   }
 
   Object _cacheKey() =>
-      _AnimationCacheKey(widget.bytesLoader.cacheKey(context), widget.frameRate, widget.maxFrames);
+      AnimatedSvgCacheKey(widget.bytesLoader.cacheKey(context), widget.frameRate, widget.maxFrames);
 
   Future<void> _load() async {
     final SvgSourceLoader<Object?> loader = widget.bytesLoader;

--- a/lib/src/animation/cache.dart
+++ b/lib/src/animation/cache.dart
@@ -193,6 +193,41 @@ class AnimationCache {
   }
 }
 
+/// What a compiled animation is cached under.
+///
+/// Built in one place because two of them have to agree exactly: the widget
+/// looks an animation up by this, and [precacheAnimatedSvg] stores it by this.
+/// If they ever computed it differently, precaching would appear to work and
+/// quietly do nothing, since a miss is indistinguishable from never having
+/// been asked.
+@immutable
+class AnimatedSvgCacheKey {
+  /// See class doc.
+  const AnimatedSvgCacheKey(this.loaderKey, this.frameRate, this.maxFrames);
+
+  /// What the loader says identifies its source.
+  final Object loaderKey;
+
+  /// Frames compiled per second, which changes what was compiled.
+  final double frameRate;
+
+  /// The ceiling on the frame count, which changes it too.
+  final int maxFrames;
+
+  @override
+  bool operator ==(Object other) =>
+      other is AnimatedSvgCacheKey &&
+      other.loaderKey == loaderKey &&
+      other.frameRate == frameRate &&
+      other.maxFrames == maxFrames;
+
+  @override
+  int get hashCode => Object.hash(loaderKey, frameRate, maxFrames);
+
+  @override
+  String toString() => 'AnimatedSvgCacheKey($loaderKey, ${frameRate}fps, max $maxFrames)';
+}
+
 /// The cache of compiled animations shared by every [AnimatedSvgPicture].
 ///
 /// Entries are large, because an animation holds one compiled vector graphic

--- a/lib/src/precache.dart
+++ b/lib/src/precache.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/widgets.dart';
+
+import 'animation/cache.dart';
+import 'animation/frames.dart';
+import 'color_mapper.dart';
+import 'loaders.dart';
+
+/// Compiles an animation into the shared cache before anything shows it.
+///
+/// Compiling is the expensive part of drawing an animated SVG, and it happens
+/// when the picture is first built: a large document takes long enough that
+/// there is a placeholder, then a still first frame, and only then movement.
+/// Doing it on the screen before, where there is time to spare, means the
+/// picture is there the moment the widget is.
+///
+/// ```dart
+/// @override
+/// void didChangeDependencies() {
+///   super.didChangeDependencies();
+///   precacheAnimatedSvg(const SvgAnimateAssetLoader('assets/intro.svg'), context);
+/// }
+/// ```
+///
+/// [context] is what a loader resolves an enclosing `DefaultSvgTheme` and
+/// `DefaultAssetBundle` against, so pass the one the picture will be built
+/// under. Passing null is fine for a loader that needs neither, such as one
+/// reading a string or a file.
+///
+/// [frameRate] and [maxFrames] must match what the picture will be built with,
+/// because an animation compiled at one frame rate is not the animation
+/// compiled at another and is cached separately.
+///
+/// Returns the compiled frames, which can say what the animation cost:
+///
+/// ```dart
+/// final AnimatedSvgFrames frames = await precacheAnimatedSvg(loader, context);
+/// debugPrint('${frames.frameCount} frames, ${frames.compiledByteSize} bytes');
+/// ```
+///
+/// Reading a source that is not there, or one that is not well formed XML,
+/// throws here rather than when the picture is built. Catch it if a failed
+/// precache should not be a failed screen; the picture will report the same
+/// error again through its own `errorBuilder` when it is built.
+///
+/// Precaching the same animation twice compiles it once. An animation the cache
+/// has already evicted is compiled again, so precache near where it is shown
+/// rather than at the start of the app.
+Future<AnimatedSvgFrames> precacheAnimatedSvg(
+  SvgSourceLoader<Object?> loader,
+  BuildContext? context, {
+  double frameRate = defaultAnimationFrameRate,
+  int maxFrames = defaultMaxAnimationFrames,
+}) {
+  assert(frameRate > 0);
+  assert(maxFrames > 0);
+  // The same key the widget will look it up under, built by the same class, so
+  // that the two cannot drift apart into a precache that silently does nothing.
+  final key = AnimatedSvgCacheKey(loader.cacheKey(context), frameRate, maxFrames);
+  return svgAnimateCache.putIfAbsent(
+    key,
+    // Chained rather than awaited. A loader reading a string or bytes completes
+    // synchronously, and awaiting a synchronous future runs what follows before
+    // this has been wrapped in a future that can hold an error: a document that
+    // fails to parse then escapes as an unhandled exception instead of
+    // completing this one. `putIfAbsent` wraps the chain in `Future.sync`,
+    // which is what catches it.
+    () => loader
+        .loadSvgSource(context)
+        .then(
+          (SvgSource source) => compileAnimatedSvgFrames(
+            source.xml,
+            theme: source.theme.toVgTheme(),
+            colorMapper: toVgColorMapper(source.colorMapper),
+            frameRate: frameRate,
+            maxFrames: maxFrames,
+            debugName: loader.toString(),
+          ),
+        ),
+  );
+}

--- a/lib/svg_animate.dart
+++ b/lib/svg_animate.dart
@@ -11,11 +11,12 @@
 library;
 
 export 'src/animated_svg.dart';
-export 'src/animation/cache.dart' show AnimationCache, svgAnimateCache;
+export 'src/animation/cache.dart' show AnimatedSvgCacheKey, AnimationCache, svgAnimateCache;
 export 'src/animation/diagnostics.dart'
     show SvgAnimateDiagnostic, SvgAnimateDiagnosticKind, svgAnimateReportDiagnostics;
 export 'src/animation/frames.dart'
     show AnimatedSvgFrames, defaultAnimationFrameRate, defaultMaxAnimationFrames;
 export 'src/compile.dart' show compileAnimatedSvg;
+export 'src/precache.dart' show precacheAnimatedSvg;
 export 'src/color_mapper.dart' show toVgColorMapper;
 export 'src/loaders.dart';

--- a/test/precache_test.dart
+++ b/test/precache_test.dart
@@ -1,0 +1,175 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_svg/flutter_svg.dart' show DefaultSvgTheme, SvgTheme;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:svg_animate/svg_animate.dart';
+
+const String spinning = '''
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="10" height="10" fill="#f00">
+    <animate attributeName="x" dur="1s" values="0;90" repeatCount="indefinite"/>
+  </rect>
+</svg>''';
+
+/// Counts how many times it is asked for its source.
+///
+/// Counted in [prepareMessage], which is documented to run on the main isolate,
+/// rather than in [provideSvg], which is meant to run in another one.
+class _CountingLoader extends SvgSourceLoader<void> {
+  _CountingLoader(this.markup);
+
+  final String markup;
+
+  /// Every context the source has been read under.
+  ///
+  /// A list rather than a counter because a loader is `@immutable`, and a
+  /// final list that grows keeps that promise where a field that counts up
+  /// would not.
+  final List<BuildContext?> reads = <BuildContext?>[];
+
+  @override
+  Future<void> prepareMessage(BuildContext? context) {
+    reads.add(context);
+    return SynchronousFuture<void>(null);
+  }
+
+  @override
+  String provideSvg(void message) => markup;
+}
+
+/// Builds the picture and waits for it to have loaded.
+Future<void> show(
+  WidgetTester tester,
+  SvgSourceLoader<Object?> loader, {
+  double frameRate = defaultAnimationFrameRate,
+}) async {
+  await tester.pumpWidget(
+    Directionality(
+      textDirection: TextDirection.ltr,
+      child: AnimatedSvgPicture(
+        loader,
+        width: 100,
+        height: 100,
+        autoPlay: false,
+        frameRate: frameRate,
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  // The cache is shared by the whole library, so a test that left something in
+  // it would decide the result of the next one.
+  setUp(svgAnimateCache.clear);
+  tearDown(svgAnimateCache.clear);
+
+  test('compiles the animation and reports what it cost', () async {
+    final AnimatedSvgFrames frames = await precacheAnimatedSvg(
+      const SvgAnimateStringLoader(spinning),
+      null,
+    );
+
+    expect(frames.frameCount, greaterThan(1));
+    expect(frames.isAnimated, isTrue);
+    expect(frames.compiledByteSize, greaterThan(0));
+  });
+
+  test('puts it in the shared cache', () async {
+    expect(svgAnimateCache.count, 0);
+    await precacheAnimatedSvg(const SvgAnimateStringLoader(spinning), null);
+    expect(svgAnimateCache.count, 1);
+  });
+
+  test('compiles once when asked twice', () async {
+    final _CountingLoader loader = _CountingLoader(spinning);
+
+    await precacheAnimatedSvg(loader, null);
+    await precacheAnimatedSvg(loader, null);
+
+    expect(loader.reads.length, 1);
+  });
+
+  // The point of the whole thing. The widget looks the animation up under a key
+  // it builds itself; if precaching built a different one, it would appear to
+  // work and quietly do nothing, because a cache miss looks exactly like never
+  // having been asked.
+  testWidgets('is what the picture then finds, without reading again', (WidgetTester tester) async {
+    final _CountingLoader loader = _CountingLoader(spinning);
+    await precacheAnimatedSvg(loader, null);
+    expect(loader.reads.length, 1);
+
+    await show(tester, loader);
+
+    expect(loader.reads.length, 1, reason: 'the picture found it rather than compiling it again');
+  });
+
+  testWidgets('a picture built without one does read its source', (WidgetTester tester) async {
+    // The other half: without precaching the count does move, so the test above
+    // is measuring something.
+    final _CountingLoader loader = _CountingLoader(spinning);
+    await show(tester, loader);
+
+    expect(loader.reads.length, 1);
+  });
+
+  testWidgets('a different frame rate is a different animation', (WidgetTester tester) async {
+    // Frames compiled at 60 fps are not the frames compiled at 30, so they are
+    // cached apart and precaching one does not stand in for the other.
+    final _CountingLoader loader = _CountingLoader(spinning);
+    await precacheAnimatedSvg(loader, null, frameRate: 60);
+
+    await show(tester, loader, frameRate: 30);
+
+    expect(loader.reads.length, 2);
+    expect(svgAnimateCache.count, 2);
+  });
+
+  testWidgets('reads the theme from the context it is given', (WidgetTester tester) async {
+    // An enclosing DefaultSvgTheme decides what `currentColor` compiles to, so
+    // it has to be read where the picture will read it. Precaching against a
+    // context inside the theme and then showing the picture inside the same
+    // theme has to be one animation, not two.
+    const SvgTheme green = SvgTheme(currentColor: Color(0xFF00FF00));
+    final _CountingLoader loader = _CountingLoader(spinning);
+    BuildContext? captured;
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: DefaultSvgTheme(
+          theme: green,
+          child: Builder(
+            builder: (BuildContext context) {
+              captured = context;
+              return const SizedBox();
+            },
+          ),
+        ),
+      ),
+    );
+    await precacheAnimatedSvg(loader, captured);
+    expect(loader.reads.length, 1);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: DefaultSvgTheme(
+          theme: green,
+          child: AnimatedSvgPicture(loader, width: 100, height: 100, autoPlay: false),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(loader.reads.length, 1, reason: 'the same theme is the same animation');
+  });
+
+  test('reports a broken document rather than hiding it until the picture is built', () async {
+    await expectLater(
+      precacheAnimatedSvg(const SvgAnimateStringLoader('<svg><unclosed></svg>'), null),
+      throwsA(anything),
+    );
+    expect(svgAnimateCache.count, 0, reason: 'nothing half compiled is left behind');
+  });
+}


### PR DESCRIPTION
Compiling is the expensive part of drawing an animated SVG, and it happened when the picture was first built: a placeholder, then a still first frame, and only then movement. Progressive loading made that wait short. It could not make it absent.

Nothing could do the work earlier, either. The key a picture looks an animation up under was private to the widget, and `compileAnimatedSvg` compiles without caching, so there was no way to put anything where a picture would find it.

```dart
@override
void didChangeDependencies() {
  super.didChangeDependencies();
  precacheAnimatedSvg(const SvgAnimateAssetLoader('assets/intro.svg'), context);
}
```

## the thing that had to be right

If precaching built a different key from the one the widget looks under, it would **appear to work and do nothing**, because a cache miss is indistinguishable from never having been asked. That is the failure this package keeps meeting: no error, no log, just the old slow behaviour.

So the key is one class now, used by both, and the test counts how many times the loader is actually read:

| | reads |
|---|---|
| precache, then show the picture | **1** |
| show the picture without precaching | 1 |
| precache at 60 fps, show at 30 | **2** — separate animations, cached apart |

One if the picture found what was precached, two if the keys ever drift.

## a bug I wrote and the tests caught

I wrote the body with `await` and it was wrong.

A loader reading a string completes synchronously. Awaiting a synchronous future runs what follows before there is a future to hold an error, so a document that fails to parse escaped as an **unhandled exception** rather than completing the returned one.

What makes this worth writing down: the widget already carries a comment saying exactly this about its own loading, the cache carries another explaining why it wraps in `Future.sync`, I had read both earlier the same day, and I still wrote it.

It was found by the test failing for the string loader and passing for a genuinely asynchronous one. It chains now, which is what that `Future.sync` exists to catch.

## also

`AnimatedSvgCacheKey` is exported, which incidentally repairs something: `AnimationCache`'s `[]` and `evict` both take a key, and until now a caller had no way to build one.

## verified

Eight new tests: what is compiled and cached, that asking twice compiles once, that the picture then finds it without reading again, that a different frame rate is a different animation, that the theme comes from the context given, and that a broken document reports at precache time rather than waiting for the picture.

201 tests, analyzer clean.
